### PR TITLE
Increased attack time on piano resonance

### DIFF
--- a/Sonatina Symphonic Orchestra/Grand Piano/Data/Res.txt
+++ b/Sonatina Symphonic Orchestra/Grand Piano/Data/Res.txt
@@ -1,5 +1,5 @@
 group_volume=-11
-ampeg_attack=0.1
+ampeg_attack=0.2
 
 <region> lokey=021 hikey=022 pitch_keycenter=033 sample=PP A0.$EXT
 <region> lokey=023 hikey=023 pitch_keycenter=035 sample=PP B0.$EXT offset=618


### PR DESCRIPTION
When you play a note on a piano, the pitch tends to be slightly flat at first and take a fraction of a second to settle down to the correct frequency.  This can cause problems when using higher notes to emulate string resonance.  Depending on the particular samples being played, they can momentarily be out of tune with each other.  The problem can be fixed by increasing the attack time on the resonance samples to give the pitch more time to settle down.