### PR TITLE
Updated links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,4 +185,4 @@ has its own sound, so try them all out.
 
 - [Virtual Playing Orchestra](http://virtualplaying.com/virtual-playing-orchestra/)
 - [Versilian Studios Chamber Orchestra Community Edition](http://vis.versilstudios.net/vsco-community.html)
-- [No Budget Orchestra](https://nbo.libreorchestra.net/download/)
+- [BBC Symphony Orchestra Discover Edition](https://www.spitfireaudio.com/bbc-symphony-orchestra-discover)


### PR DESCRIPTION
I removed the link to No Budget Orchestra, which doesn't seem to be available anymore, and added a link to BBCSO Discover.