### PR TITLE
Added demo track to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The instruments are packaged in SFZ format.  They can be used with any compatibl
 [Sforzando](https://www.plogue.com/products/sforzando/) and [sfizz](https://sfz.tools/sfizz/).  Other players often
 have less complete support for the format, so some features may not work correctly on them.
 
+Here is an example created entirely with Sonatina Symphonic Orchestra, so you can hear what it sounds like.
+
+<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1894950753&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/peter-eastman-195718857" title="Peter Eastman" target="_blank" style="color: #cccccc; text-decoration: none;">Peter Eastman</a> · <a href="https://soundcloud.com/peter-eastman-195718857/tchaikovsky-swan-lake-act-2-no-10" title="Tchaikovsky: Swan Lake Act 2, No. 10" target="_blank" style="color: #cccccc; text-decoration: none;">Tchaikovsky: Swan Lake Act 2, No. 10</a></div>
+
 Instruments
 -----------
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ The instruments are packaged in SFZ format.  They can be used with any compatibl
 [Sforzando](https://www.plogue.com/products/sforzando/) and [sfizz](https://sfz.tools/sfizz/).  Other players often
 have less complete support for the format, so some features may not work correctly on them.
 
-Here is an example created entirely with Sonatina Symphonic Orchestra, so you can hear what it sounds like.
-
-<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1894950753&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/peter-eastman-195718857" title="Peter Eastman" target="_blank" style="color: #cccccc; text-decoration: none;">Peter Eastman</a> · <a href="https://soundcloud.com/peter-eastman-195718857/tchaikovsky-swan-lake-act-2-no-10" title="Tchaikovsky: Swan Lake Act 2, No. 10" target="_blank" style="color: #cccccc; text-decoration: none;">Tchaikovsky: Swan Lake Act 2, No. 10</a></div>
+[Here is an example](https://on.soundcloud.com/JkDurSyxMf2xavhG7) created entirely with Sonatina Symphonic Orchestra,
+so you can hear what it sounds like.
 
 Instruments
 -----------


### PR DESCRIPTION
This adds a link to a demo track.  I was hoping to embed the player in the README, but it seems github doesn't support the HTML features needed to do that.