### PR TITLE
Made stereo width more consistent

### DIFF
--- a/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Col Legno.sfz
@@ -14,7 +14,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-p.flac
 lokey=g3
 hikey=a#3
 pitch_keycenter=g3
-pan=3
+pan=8
 tune=-5
 
 <region>
@@ -22,7 +22,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-pp.flac
 lokey=g3
 hikey=b3
 pitch_keycenter=g3
-pan=10
+pan=25
 tune=-13
 
 <region>
@@ -30,7 +30,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#3-p.flac
 lokey=g3
 hikey=c#4
 pitch_keycenter=a#3
-pan=3
+pan=8
 tune=3
 
 <region>
@@ -38,7 +38,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-p.flac
 lokey=g3
 hikey=d#4
 pitch_keycenter=c#4
-pan=-10
+pan=-25
 tune=23
 
 <region>
@@ -46,7 +46,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-pp.flac
 lokey=b3
 hikey=d#4
 pitch_keycenter=c#4
-pan=-3
+pan=-8
 tune=9
 
 <region>
@@ -54,7 +54,7 @@ sample=../Samples/1st Violins/1st-violins-col-d4-pp.flac
 lokey=c4
 hikey=d#4
 pitch_keycenter=d4
-pan=10
+pan=25
 tune=0
 
 <region>
@@ -62,7 +62,7 @@ sample=../Samples/1st Violins/1st-violins-col-e4-p.flac
 lokey=d4
 hikey=f4
 pitch_keycenter=e4
-pan=-10
+pan=-25
 tune=-7
 
 <region>
@@ -70,7 +70,7 @@ sample=../Samples/1st Violins/1st-violins-col-e4-pp.flac
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
-pan=-3
+pan=-8
 tune=0
 
 <region>
@@ -78,7 +78,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-p.flac
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
-pan=3
+pan=8
 tune=-14
 
 <region>
@@ -86,7 +86,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-pp.flac
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
-pan=10
+pan=25
 tune=0
 
 <region>
@@ -94,7 +94,7 @@ sample=../Samples/1st Violins/1st-violins-col-f#4-p.flac
 lokey=f#4
 hikey=g4
 pitch_keycenter=f#4
-pan=-10
+pan=-25
 tune=-2
 
 <region>
@@ -102,7 +102,7 @@ sample=../Samples/1st Violins/1st-violins-col-f#4-pp.flac
 lokey=f#4
 hikey=g4
 pitch_keycenter=f#4
-pan=-3
+pan=-8
 tune=-17
 
 <region>
@@ -110,7 +110,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-p.flac
 lokey=g4
 hikey=g#4
 pitch_keycenter=g4
-pan=3
+pan=8
 tune=-2
 
 <region>
@@ -118,7 +118,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-pp.flac
 lokey=g4
 hikey=g#4
 pitch_keycenter=g4
-pan=10
+pan=25
 tune=-3
 
 <region>
@@ -126,7 +126,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#4-p.flac
 lokey=g#4
 hikey=b4
 pitch_keycenter=a#4
-pan=-10
+pan=-25
 tune=-26
 
 <region>
@@ -134,7 +134,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#4-p2.flac
 lokey=g#4
 hikey=b4
 pitch_keycenter=a#4
-pan=-3
+pan=-8
 tune=-8
 
 <region>
@@ -142,7 +142,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-p.flac
 lokey=a4
 hikey=c5
 pitch_keycenter=b4
-pan=3
+pan=8
 tune=6
 
 <region>
@@ -150,7 +150,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-pp.flac
 lokey=a4
 hikey=c5
 pitch_keycenter=b4
-pan=10
+pan=25
 tune=-5
 
 <region>
@@ -158,7 +158,7 @@ sample=../Samples/1st Violins/1st-violins-col-c5-p.flac
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
-pan=-10
+pan=-25
 tune=9
 
 <region>
@@ -166,7 +166,7 @@ sample=../Samples/1st Violins/1st-violins-col-c5-pp.flac
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
-pan=-3
+pan=-8
 tune=53
 
 <region>
@@ -174,7 +174,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-p.flac
 lokey=c#5
 hikey=e5
 pitch_keycenter=d#5
-pan=3
+pan=8
 tune=-21
 
 <region>
@@ -182,7 +182,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-pp.flac
 lokey=c#5
 hikey=e5
 pitch_keycenter=d#5
-pan=10
+pan=25
 tune=4
 
 <region>
@@ -190,7 +190,7 @@ sample=../Samples/1st Violins/1st-violins-col-e5-p.flac
 lokey=d5
 hikey=f#5
 pitch_keycenter=e5
-pan=-10
+pan=-25
 tune=5
 
 <region>
@@ -198,7 +198,7 @@ sample=../Samples/1st Violins/1st-violins-col-e5-pp.flac
 lokey=d5
 hikey=f#5
 pitch_keycenter=e5
-pan=-3
+pan=-8
 tune=-10
 
 <region>
@@ -206,7 +206,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-p.flac
 lokey=f5
 hikey=a5
 pitch_keycenter=g#5
-pan=3
+pan=8
 tune=-5
 
 <region>
@@ -214,7 +214,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-pp.flac
 lokey=f5
 hikey=a5
 pitch_keycenter=g#5
-pan=10
+pan=25
 tune=-11
 
 <region>
@@ -222,7 +222,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#5-p.flac
 lokey=g5
 hikey=b5
 pitch_keycenter=a#5
-pan=-10
+pan=-25
 tune=0
 
 <region>
@@ -230,7 +230,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#5-pp.flac
 lokey=g5
 hikey=b5
 pitch_keycenter=a#5
-pan=-3
+pan=-8
 tune=17
 
 <region>
@@ -238,7 +238,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-p.flac
 lokey=a#5
 hikey=d#6
 pitch_keycenter=b5
-pan=3
+pan=8
 tune=0
 
 <region>
@@ -246,7 +246,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-pp.flac
 lokey=a#5
 hikey=d#6
 pitch_keycenter=b5
-pan=10
+pan=25
 tune=0
 
 <region>
@@ -254,7 +254,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#6-p.flac
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
-pan=-10
+pan=-25
 tune=9
 
 <region>
@@ -262,7 +262,7 @@ sample=../Samples/1st Violins/1st-violins-col-d6-pp.flac
 lokey=c6
 hikey=c7
 pitch_keycenter=d6
-pan=-3
+pan=-8
 tune=-25
 
 <region>
@@ -270,7 +270,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#6-p.flac
 lokey=d#6
 hikey=c7
 pitch_keycenter=d#6
-pan=-10
+pan=-25
 tune=27
 
 <region>
@@ -278,7 +278,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#6-p.flac
 lokey=e6
 hikey=c7
 pitch_keycenter=g#6
-pan=3
+pan=8
 tune=-36
 
 <region>
@@ -286,5 +286,5 @@ sample=../Samples/1st Violins/1st-violins-col-c#7-pp.flac
 lokey=e6
 hikey=c7
 pitch_keycenter=c#7
-pan=10
+pan=25
 tune=9

--- a/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Pizzicato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Pizzicato.sfz
@@ -11,6 +11,7 @@ seq_length=2
 ampeg_sustain=0
 ampeg_decay=1
 ampeg_vel2decay=10
+width=50
 
 <region>
 sample=..\Samples\1st Violins\1st-violins-piz-rr1-g3.wav
@@ -106,6 +107,7 @@ transpose=-1
 ampeg_sustain=0
 ampeg_decay=1
 ampeg_vel2decay=10
+width=50
 
 <region>
 sample=..\Samples\1st Violins\1st-violins-piz-rr2-g3.wav

--- a/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Col Legno.sfz
@@ -14,7 +14,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-p.flac
 lokey=g3
 hikey=a#3
 pitch_keycenter=g3
-pan=-3
+pan=-8
 tune=-5
 
 <region>
@@ -22,7 +22,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-pp.flac
 lokey=g3
 hikey=b3
 pitch_keycenter=g3
-pan=-10
+pan=-25
 tune=-13
 
 <region>
@@ -30,7 +30,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#3-p.flac
 lokey=g3
 hikey=c#4
 pitch_keycenter=a#3
-pan=-3
+pan=-8
 tune=3
 
 <region>
@@ -38,7 +38,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-p.flac
 lokey=g3
 hikey=d#4
 pitch_keycenter=c#4
-pan=10
+pan=25
 tune=23
 
 <region>
@@ -46,7 +46,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-pp.flac
 lokey=b3
 hikey=d#4
 pitch_keycenter=c#4
-pan=3
+pan=8
 tune=9
 
 <region>
@@ -54,7 +54,7 @@ sample=../Samples/1st Violins/1st-violins-col-d4-pp.flac
 lokey=c4
 hikey=d#4
 pitch_keycenter=d4
-pan=-10
+pan=-25
 tune=0
 
 <region>
@@ -62,7 +62,7 @@ sample=../Samples/1st Violins/1st-violins-col-e4-p.flac
 lokey=d4
 hikey=f4
 pitch_keycenter=e4
-pan=10
+pan=25
 tune=-7
 
 <region>
@@ -70,7 +70,7 @@ sample=../Samples/1st Violins/1st-violins-col-e4-pp.flac
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
-pan=3
+pan=8
 tune=0
 
 <region>
@@ -78,7 +78,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-p.flac
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
-pan=-3
+pan=-8
 tune=-14
 
 <region>
@@ -86,7 +86,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-pp.flac
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
-pan=-10
+pan=-25
 tune=0
 
 <region>
@@ -94,7 +94,7 @@ sample=../Samples/1st Violins/1st-violins-col-f#4-p.flac
 lokey=f#4
 hikey=g4
 pitch_keycenter=f#4
-pan=10
+pan=25
 tune=-2
 
 <region>
@@ -102,7 +102,7 @@ sample=../Samples/1st Violins/1st-violins-col-f#4-pp.flac
 lokey=f#4
 hikey=g4
 pitch_keycenter=f#4
-pan=3
+pan=8
 tune=-17
 
 <region>
@@ -110,7 +110,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-p.flac
 lokey=g4
 hikey=g#4
 pitch_keycenter=g4
-pan=-3
+pan=-8
 tune=-2
 
 <region>
@@ -118,7 +118,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-pp.flac
 lokey=g4
 hikey=g#4
 pitch_keycenter=g4
-pan=-10
+pan=-25
 tune=-3
 
 <region>
@@ -126,7 +126,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#4-p.flac
 lokey=g#4
 hikey=b4
 pitch_keycenter=a#4
-pan=10
+pan=25
 tune=-26
 
 <region>
@@ -134,7 +134,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#4-p2.flac
 lokey=g#4
 hikey=b4
 pitch_keycenter=a#4
-pan=3
+pan=8
 tune=-8
 
 <region>
@@ -142,7 +142,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-p.flac
 lokey=a4
 hikey=c5
 pitch_keycenter=b4
-pan=-3
+pan=-8
 tune=6
 
 <region>
@@ -150,7 +150,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-pp.flac
 lokey=a4
 hikey=c5
 pitch_keycenter=b4
-pan=-10
+pan=-25
 tune=-5
 
 <region>
@@ -158,7 +158,7 @@ sample=../Samples/1st Violins/1st-violins-col-c5-p.flac
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
-pan=10
+pan=25
 tune=9
 
 <region>
@@ -166,7 +166,7 @@ sample=../Samples/1st Violins/1st-violins-col-c5-pp.flac
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
-pan=3
+pan=8
 tune=53
 
 <region>
@@ -174,7 +174,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-p.flac
 lokey=c#5
 hikey=e5
 pitch_keycenter=d#5
-pan=-3
+pan=-8
 tune=-21
 
 <region>
@@ -182,7 +182,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-pp.flac
 lokey=c#5
 hikey=e5
 pitch_keycenter=d#5
-pan=-10
+pan=-25
 tune=4
 
 <region>
@@ -190,7 +190,7 @@ sample=../Samples/1st Violins/1st-violins-col-e5-p.flac
 lokey=d5
 hikey=f#5
 pitch_keycenter=e5
-pan=10
+pan=25
 tune=5
 
 <region>
@@ -198,7 +198,7 @@ sample=../Samples/1st Violins/1st-violins-col-e5-pp.flac
 lokey=d5
 hikey=f#5
 pitch_keycenter=e5
-pan=3
+pan=8
 tune=-10
 
 <region>
@@ -206,7 +206,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-p.flac
 lokey=f5
 hikey=a5
 pitch_keycenter=g#5
-pan=-3
+pan=-8
 tune=-5
 
 <region>
@@ -214,7 +214,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-pp.flac
 lokey=f5
 hikey=a5
 pitch_keycenter=g#5
-pan=-10
+pan=-25
 tune=-11
 
 <region>
@@ -222,7 +222,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#5-p.flac
 lokey=g5
 hikey=b5
 pitch_keycenter=a#5
-pan=10
+pan=25
 tune=0
 
 <region>
@@ -230,7 +230,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#5-pp.flac
 lokey=g5
 hikey=b5
 pitch_keycenter=a#5
-pan=3
+pan=8
 tune=17
 
 <region>
@@ -238,7 +238,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-p.flac
 lokey=a#5
 hikey=d#6
 pitch_keycenter=b5
-pan=-3
+pan=-8
 tune=0
 
 <region>
@@ -246,7 +246,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-pp.flac
 lokey=a#5
 hikey=d#6
 pitch_keycenter=b5
-pan=-10
+pan=-25
 tune=0
 
 <region>
@@ -254,7 +254,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#6-p.flac
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
-pan=10
+pan=25
 tune=9
 
 <region>
@@ -262,7 +262,7 @@ sample=../Samples/1st Violins/1st-violins-col-d6-pp.flac
 lokey=c6
 hikey=c7
 pitch_keycenter=d6
-pan=3
+pan=8
 tune=-25
 
 <region>
@@ -270,7 +270,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#6-p.flac
 lokey=d#6
 hikey=c7
 pitch_keycenter=d#6
-pan=10
+pan=25
 tune=27
 
 <region>
@@ -278,7 +278,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#6-p.flac
 lokey=e6
 hikey=c7
 pitch_keycenter=g#6
-pan=-3
+pan=-8
 tune=-36
 
 <region>
@@ -286,5 +286,5 @@ sample=../Samples/1st Violins/1st-violins-col-c#7-pp.flac
 lokey=e6
 hikey=c7
 pitch_keycenter=c#7
-pan=-10
+pan=-25
 tune=9

--- a/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Pizzicato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Pizzicato.sfz
@@ -11,6 +11,7 @@ seq_length=2
 ampeg_sustain=0
 ampeg_decay=1
 ampeg_vel2decay=10
+width=50
 
 <region>
 sample=..\Samples\2nd Violins\2nd-violins-piz-rr1-g3.wav
@@ -106,6 +107,7 @@ transpose=-1
 ampeg_sustain=0
 ampeg_decay=1
 ampeg_vel2decay=10
+width=50
 
 <region>
 sample=..\Samples\2nd Violins\2nd-violins-piz-rr2-g3.wav

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Basses Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Basses Col Legno.sfz
@@ -19,7 +19,7 @@ lokey=c1
 hikey=g1
 tune=-26
 volume=-2
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-f1.flac
@@ -28,7 +28,7 @@ lokey=c1
 hikey=a1
 tune=-13
 volume=5
-pan=7
+pan=20
 
 <region>
 sample=../Samples/Basses/basses-col-a#1.flac
@@ -37,7 +37,7 @@ lokey=g#1
 hikey=d2
 tune=-8
 volume=1
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-d2.flac
@@ -46,7 +46,7 @@ lokey=a#1
 hikey=e2
 tune=-48
 volume=0
-pan=7
+pan=20
 
 <region>
 sample=../Samples/Basses/basses-col-g2.flac
@@ -55,7 +55,7 @@ lokey=d#2
 hikey=g2
 tune=-42
 volume=0
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-g2-2.flac
@@ -63,7 +63,7 @@ pitch_keycenter=g2
 lokey=f2
 hikey=g#2
 volume=0
-pan=7
+pan=20
 
 <region>
 sample=../Samples/Basses/basses-col-g#2.flac
@@ -72,7 +72,7 @@ lokey=g#2
 hikey=a#2
 tune=-23
 volume=0
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-a2.flac
@@ -81,7 +81,7 @@ lokey=a2
 hikey=c#3
 tune=-25
 volume=-2
-pan=7
+pan=20
 
 <region>
 sample=../Samples/Basses/basses-col-c#3.flac
@@ -90,7 +90,7 @@ lokey=b2
 hikey=a3
 tune=-36
 volume=0
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-f#3.flac
@@ -99,7 +99,7 @@ lokey=d3
 hikey=a3
 tune=-39
 volume=2
-pan=7
+pan=20
 
 
 // Borrowed cello samples

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Celli Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Celli Col Legno.sfz
@@ -17,7 +17,7 @@ sample=../Samples/Celli/celli-col-c2.flac
 pitch_keycenter=c2
 lokey=c2
 hikey=d#2
-pan=-10
+pan=-25
 tune=10
 volume=1
 
@@ -26,7 +26,7 @@ sample=../Samples/Celli/celli-col-c#2.flac
 pitch_keycenter=c#2
 lokey=c2
 hikey=e2
-pan=-3
+pan=-8
 tune=8
 volume=-2
 
@@ -35,7 +35,7 @@ sample=../Samples/Celli/celli-col-d#2.flac
 pitch_keycenter=d#2
 lokey=c2
 hikey=f#2
-pan=10
+pan=25
 tune=11
 volume=2
 
@@ -44,7 +44,7 @@ sample=../Samples/Celli/celli-col-f#2.flac
 pitch_keycenter=f#2
 lokey=e2
 hikey=g#2
-pan=-10
+pan=-25
 tune=-30
 volume=-1
 
@@ -53,7 +53,7 @@ sample=../Samples/Celli/celli-col-g2.flac
 pitch_keycenter=g2
 lokey=f2
 hikey=a2
-pan=-3
+pan=-8
 tune=15
 volume=-2
 
@@ -62,7 +62,7 @@ sample=../Samples/Celli/celli-col-a2.flac
 pitch_keycenter=a2
 lokey=g2
 hikey=a#2
-pan=10
+pan=25
 tune=-1
 volume=0
 
@@ -71,7 +71,7 @@ sample=../Samples/Celli/celli-col-a#2.flac
 pitch_keycenter=a#2
 lokey=a2
 hikey=c#3
-pan=-10
+pan=-25
 tune=29
 volume=3
 
@@ -80,7 +80,7 @@ sample=../Samples/Celli/celli-col-b2.flac
 pitch_keycenter=b2
 lokey=a#2
 hikey=d3
-pan=-3
+pan=-8
 volume=-1
 
 <region>
@@ -88,7 +88,7 @@ sample=../Samples/Celli/celli-col-c3.flac
 pitch_keycenter=c3
 lokey=b2
 hikey=d#3
-pan=10
+pan=25
 tune=-5
 volume=1
 
@@ -97,7 +97,7 @@ sample=../Samples/Celli/celli-col-e3.flac
 pitch_keycenter=e3
 lokey=d3
 hikey=f#3
-pan=-10
+pan=-25
 volume=-3
 
 <region>
@@ -105,7 +105,7 @@ sample=../Samples/Celli/celli-col-f3.flac
 pitch_keycenter=f3
 lokey=d#3
 hikey=g3
-pan=-3
+pan=-8
 tune=7
 volume=1
 
@@ -114,7 +114,7 @@ sample=../Samples/Celli/celli-col-f#3.flac
 pitch_keycenter=f#3
 lokey=e3
 hikey=a#3
-pan=10
+pan=25
 tune=26
 volume=0
 
@@ -123,7 +123,7 @@ sample=../Samples/Celli/celli-col-g#3.flac
 pitch_keycenter=g#3
 lokey=g3
 hikey=b3
-pan=-10
+pan=-25
 tune=-11
 volume=2
 
@@ -132,7 +132,7 @@ sample=../Samples/Celli/celli-col-a3.flac
 pitch_keycenter=a3
 lokey=g#3
 hikey=d4
-pan=-3
+pan=-8
 tune=-3
 volume=0
 
@@ -141,7 +141,7 @@ sample=../Samples/Celli/celli-col-c#4.flac
 pitch_keycenter=c#4
 lokey=b3
 hikey=g4
-pan=10
+pan=25
 volume=0
 
 <region>
@@ -149,7 +149,7 @@ sample=../Samples/Celli/celli-col-d#4.flac
 pitch_keycenter=d#4
 lokey=c4
 hikey=g4
-pan=-10
+pan=-25
 tune=-21
 volume=1
 
@@ -158,7 +158,7 @@ sample=../Samples/Celli/celli-col-g4.flac
 pitch_keycenter=g4
 lokey=d#4
 hikey=d5
-pan=-3
+pan=-8
 volume=1
 
 <region>
@@ -166,7 +166,7 @@ sample=../Samples/Celli/celli-col-d5.flac
 pitch_keycenter=d5
 lokey=g#4
 hikey=d5
-pan=10
+pan=25
 tune=-33
 volume=-1
 
@@ -179,7 +179,7 @@ sample=../Samples/Basses/basses-col-f1.flac
 pitch_keycenter=f1
 lokey=c2
 hikey=d2
-pan=3
+pan=8
 tune=-13
 volume=5
 
@@ -188,7 +188,7 @@ sample=../Samples/Basses/basses-col-a#1.flac
 pitch_keycenter=a#1
 lokey=d#2
 hikey=f#2
-pan=3
+pan=8
 tune=-8
 volume=1
 
@@ -197,7 +197,7 @@ sample=../Samples/Basses/basses-col-d2.flac
 pitch_keycenter=d2
 lokey=g2
 hikey=b2
-pan=3
+pan=8
 tune=-48
 volume=0
 
@@ -206,7 +206,7 @@ sample=../Samples/Basses/basses-col-g2.flac
 pitch_keycenter=g2
 lokey=c3
 hikey=d3
-pan=3
+pan=8
 volume=0
 tune=-42
 
@@ -215,7 +215,7 @@ sample=../Samples/Basses/basses-col-a2.flac
 pitch_keycenter=a2
 lokey=d#3
 hikey=g3
-pan=3
+pan=8
 tune=-25
 volume=-2
 
@@ -228,7 +228,7 @@ sample=../Samples/Violas/violas-col-e4.flac
 pitch_keycenter=e4
 lokey=g#3
 hikey=b3
-pan=3
+pan=8
 volume=-4
 
 <region>
@@ -236,7 +236,7 @@ sample=../Samples/Violas/violas-col-a4.flac
 pitch_keycenter=a4
 lokey=c4
 hikey=e4
-pan=3
+pan=8
 volume=-1
 
 <region>
@@ -244,5 +244,5 @@ sample=../Samples/Violas/violas-col-d5.flac
 pitch_keycenter=d5
 lokey=f4
 hikey=d5
-pan=3
+pan=8
 volume=0

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Violas Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Violas Col Legno.sfz
@@ -16,7 +16,7 @@ sample=../Samples/Violas/violas-col-c3.flac
 pitch_keycenter=c3
 lokey=c3
 hikey=e3
-pan=-10
+pan=-25
 tune=11
 volume=0
 
@@ -25,7 +25,7 @@ sample=../Samples/Violas/violas-col-f#3.flac
 pitch_keycenter=f#3
 lokey=c3
 hikey=g3
-pan=10
+pan=25
 tune=21
 volume=0
 
@@ -34,7 +34,7 @@ sample=../Samples/Violas/violas-col-g3.flac
 pitch_keycenter=g3
 lokey=f3
 hikey=g3
-pan=-10
+pan=-25
 tune=1
 volume=0
 
@@ -43,7 +43,7 @@ sample=../Samples/Violas/violas-col-g#3.flac
 pitch_keycenter=g#3
 lokey=g#3
 hikey=a3
-pan=10
+pan=25
 tune=30
 volume=1
 
@@ -52,7 +52,7 @@ sample=../Samples/Violas/violas-col-a3.flac
 pitch_keycenter=a3
 lokey=g#3
 hikey=b3
-pan=-10
+pan=-25
 tune=-34
 volume=0
 
@@ -61,7 +61,7 @@ sample=../Samples/Violas/violas-col-b3.flac
 pitch_keycenter=b3
 lokey=a#3
 hikey=c#4
-pan=10
+pan=25
 tune=-17
 volume=-2
 
@@ -70,7 +70,7 @@ sample=../Samples/Violas/violas-col-c4.flac
 pitch_keycenter=c4
 lokey=c4
 hikey=d#4
-pan=-10
+pan=-25
 tune=-4
 volume=1
 
@@ -79,7 +79,7 @@ sample=../Samples/Violas/violas-col-e4.flac
 pitch_keycenter=e4
 lokey=d4
 hikey=g4
-pan=10
+pan=25
 volume=-4
 
 <region>
@@ -87,7 +87,7 @@ sample=../Samples/Violas/violas-col-g4.flac
 pitch_keycenter=g4
 lokey=e4
 hikey=a#4
-pan=-10
+pan=-25
 volume=5
 
 <region>
@@ -95,7 +95,7 @@ sample=../Samples/Violas/violas-col-a4.flac
 pitch_keycenter=a4
 lokey=g#4
 hikey=d5
-pan=10
+pan=25
 volume=-1
 
 <region>
@@ -103,7 +103,7 @@ sample=../Samples/Violas/violas-col-d5.flac
 pitch_keycenter=d5
 lokey=b4
 hikey=a5
-pan=-10
+pan=-25
 volume=0
 
 <region>
@@ -111,7 +111,7 @@ sample=../Samples/Violas/violas-col-f#5.flac
 pitch_keycenter=f#5
 lokey=d#5
 hikey=c6
-pan=10
+pan=25
 volume=1
 
 // Borrowed violin samples
@@ -121,7 +121,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-p.flac
 lokey=c3
 hikey=d#3
 pitch_keycenter=g3
-pan=-3
+pan=-8
 tune=-5
 
 <region>
@@ -129,7 +129,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-pp.flac
 lokey=e3
 hikey=g#3
 pitch_keycenter=c#4
-pan=-3
+pan=-8
 tune=9
 
 <region>
@@ -137,7 +137,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-p.flac
 lokey=a3
 hikey=b3
 pitch_keycenter=f4
-pan=-3
+pan=-8
 tune=-14
 
 <region>
@@ -145,7 +145,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-p.flac
 lokey=c4
 hikey=c#4
 pitch_keycenter=g4
-pan=-3
+pan=-8
 tune=-2
 
 <region>
@@ -153,7 +153,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-p.flac
 lokey=d4
 hikey=f4
 pitch_keycenter=b4
-pan=-3
+pan=-8
 tune=6
 
 <region>
@@ -161,7 +161,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-p.flac
 lokey=f#4
 hikey=a4
 pitch_keycenter=d#5
-pan=-3
+pan=-8
 tune=-21
 
 <region>
@@ -169,7 +169,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-p.flac
 lokey=a#4
 hikey=d5
 pitch_keycenter=g#5
-pan=-3
+pan=-8
 tune=-5
 
 <region>
@@ -177,7 +177,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-p.flac
 lokey=d#5
 hikey=g5
 pitch_keycenter=b5
-pan=-3
+pan=-8
 tune=0
 
 <region>
@@ -185,7 +185,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#6-p.flac
 lokey=g#5
 hikey=c6
 pitch_keycenter=d#6
-pan=-3
+pan=-8
 tune=27
 
 <region>
@@ -193,7 +193,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#6-p.flac
 lokey=a#5
 hikey=c6
 pitch_keycenter=g#6
-pan=-3
+pan=-8
 tune=-36
 
 // Borrowed cello samples
@@ -203,7 +203,7 @@ sample=../Samples/Celli/celli-col-f#2.flac
 pitch_keycenter=f#2
 lokey=c3
 hikey=d3
-pan=3
+pan=8
 tune=-30
 volume=-1
 
@@ -212,7 +212,7 @@ sample=../Samples/Celli/celli-col-a#2.flac
 pitch_keycenter=a#2
 lokey=d#3
 hikey=g#3
-pan=3
+pan=8
 tune=29
 volume=3
 
@@ -221,7 +221,7 @@ sample=../Samples/Celli/celli-col-e3.flac
 pitch_keycenter=e3
 lokey=a3
 hikey=c#4
-pan=3
+pan=8
 volume=-3
 
 <region>
@@ -229,7 +229,7 @@ sample=../Samples/Celli/celli-col-a3.flac
 pitch_keycenter=a3
 lokey=d4
 hikey=f#4
-pan=3
+pan=8
 tune=-3
 volume=0
 
@@ -238,7 +238,7 @@ sample=../Samples/Celli/celli-col-d#4.flac
 pitch_keycenter=d#4
 lokey=g4
 hikey=b4
-pan=3
+pan=8
 tune=-21
 volume=1
 
@@ -247,7 +247,7 @@ sample=../Samples/Celli/celli-col-g4.flac
 pitch_keycenter=g4
 lokey=c5
 hikey=f#5
-pan=3
+pan=8
 volume=1
 
 <region>
@@ -255,6 +255,6 @@ sample=../Samples/Celli/celli-col-d5.flac
 pitch_keycenter=d5
 lokey=g5
 hikey=c6
-pan=3
+pan=8
 tune=-33
 volume=-1

--- a/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Col Legno.sfz
@@ -14,7 +14,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-p.flac
 lokey=g3
 hikey=a#3
 pitch_keycenter=g3
-pan=3
+pan=8
 tune=-5
 
 <region>
@@ -22,7 +22,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-pp.flac
 lokey=g3
 hikey=b3
 pitch_keycenter=g3
-pan=10
+pan=25
 tune=-13
 
 <region>
@@ -30,7 +30,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#3-p.flac
 lokey=g3
 hikey=c#4
 pitch_keycenter=a#3
-pan=3
+pan=8
 tune=3
 
 <region>
@@ -38,7 +38,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-p.flac
 lokey=g3
 hikey=d#4
 pitch_keycenter=c#4
-pan=-10
+pan=-25
 tune=23
 
 <region>
@@ -46,7 +46,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-pp.flac
 lokey=b3
 hikey=d#4
 pitch_keycenter=c#4
-pan=-3
+pan=-8
 tune=9
 
 <region>
@@ -54,7 +54,7 @@ sample=../Samples/1st Violins/1st-violins-col-d4-pp.flac
 lokey=c4
 hikey=d#4
 pitch_keycenter=d4
-pan=10
+pan=25
 tune=0
 
 <region>
@@ -62,7 +62,7 @@ sample=../Samples/1st Violins/1st-violins-col-e4-p.flac
 lokey=d4
 hikey=f4
 pitch_keycenter=e4
-pan=-10
+pan=-25
 tune=-7
 
 <region>
@@ -70,7 +70,7 @@ sample=../Samples/1st Violins/1st-violins-col-e4-pp.flac
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
-pan=-3
+pan=-8
 tune=0
 
 <region>
@@ -78,7 +78,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-p.flac
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
-pan=3
+pan=8
 tune=-14
 
 <region>
@@ -86,7 +86,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-pp.flac
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
-pan=10
+pan=25
 tune=0
 
 <region>
@@ -94,7 +94,7 @@ sample=../Samples/1st Violins/1st-violins-col-f#4-p.flac
 lokey=f#4
 hikey=g4
 pitch_keycenter=f#4
-pan=-10
+pan=-25
 tune=-2
 
 <region>
@@ -102,7 +102,7 @@ sample=../Samples/1st Violins/1st-violins-col-f#4-pp.flac
 lokey=f#4
 hikey=g4
 pitch_keycenter=f#4
-pan=-3
+pan=-8
 tune=-17
 
 <region>
@@ -110,7 +110,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-p.flac
 lokey=g4
 hikey=g#4
 pitch_keycenter=g4
-pan=3
+pan=8
 tune=-2
 
 <region>
@@ -118,7 +118,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-pp.flac
 lokey=g4
 hikey=g#4
 pitch_keycenter=g4
-pan=10
+pan=25
 tune=-3
 
 <region>
@@ -126,7 +126,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#4-p.flac
 lokey=g#4
 hikey=b4
 pitch_keycenter=a#4
-pan=-10
+pan=-25
 tune=-26
 
 <region>
@@ -134,7 +134,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#4-p2.flac
 lokey=g#4
 hikey=b4
 pitch_keycenter=a#4
-pan=-3
+pan=-8
 tune=-8
 
 <region>
@@ -142,7 +142,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-p.flac
 lokey=a4
 hikey=c5
 pitch_keycenter=b4
-pan=3
+pan=8
 tune=6
 
 <region>
@@ -150,7 +150,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-pp.flac
 lokey=a4
 hikey=c5
 pitch_keycenter=b4
-pan=10
+pan=25
 tune=-5
 
 <region>
@@ -158,7 +158,7 @@ sample=../Samples/1st Violins/1st-violins-col-c5-p.flac
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
-pan=-10
+pan=-25
 tune=9
 
 <region>
@@ -166,7 +166,7 @@ sample=../Samples/1st Violins/1st-violins-col-c5-pp.flac
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
-pan=-3
+pan=-8
 tune=53
 
 <region>
@@ -174,7 +174,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-p.flac
 lokey=c#5
 hikey=e5
 pitch_keycenter=d#5
-pan=3
+pan=8
 tune=-21
 
 <region>
@@ -182,7 +182,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-pp.flac
 lokey=c#5
 hikey=e5
 pitch_keycenter=d#5
-pan=10
+pan=25
 tune=4
 
 <region>
@@ -190,7 +190,7 @@ sample=../Samples/1st Violins/1st-violins-col-e5-p.flac
 lokey=d5
 hikey=f#5
 pitch_keycenter=e5
-pan=-10
+pan=-25
 tune=5
 
 <region>
@@ -198,7 +198,7 @@ sample=../Samples/1st Violins/1st-violins-col-e5-pp.flac
 lokey=d5
 hikey=f#5
 pitch_keycenter=e5
-pan=-3
+pan=-8
 tune=-10
 
 <region>
@@ -206,7 +206,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-p.flac
 lokey=f5
 hikey=a5
 pitch_keycenter=g#5
-pan=3
+pan=8
 tune=-5
 
 <region>
@@ -214,7 +214,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-pp.flac
 lokey=f5
 hikey=a5
 pitch_keycenter=g#5
-pan=10
+pan=25
 tune=-11
 
 <region>
@@ -222,7 +222,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#5-p.flac
 lokey=g5
 hikey=b5
 pitch_keycenter=a#5
-pan=-10
+pan=-25
 tune=0
 
 <region>
@@ -230,7 +230,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#5-pp.flac
 lokey=g5
 hikey=b5
 pitch_keycenter=a#5
-pan=-3
+pan=-8
 tune=17
 
 <region>
@@ -238,7 +238,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-p.flac
 lokey=a#5
 hikey=d#6
 pitch_keycenter=b5
-pan=3
+pan=8
 tune=0
 
 <region>
@@ -246,7 +246,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-pp.flac
 lokey=a#5
 hikey=d#6
 pitch_keycenter=b5
-pan=10
+pan=25
 tune=0
 
 <region>
@@ -254,7 +254,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#6-p.flac
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
-pan=-10
+pan=-25
 tune=9
 
 <region>
@@ -262,7 +262,7 @@ sample=../Samples/1st Violins/1st-violins-col-d6-pp.flac
 lokey=c6
 hikey=c7
 pitch_keycenter=d6
-pan=-3
+pan=-8
 tune=-25
 
 <region>
@@ -270,7 +270,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#6-p.flac
 lokey=d#6
 hikey=c7
 pitch_keycenter=d#6
-pan=-10
+pan=-25
 tune=27
 
 <region>
@@ -278,7 +278,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#6-p.flac
 lokey=e6
 hikey=c7
 pitch_keycenter=g#6
-pan=3
+pan=8
 tune=-36
 
 <region>
@@ -286,5 +286,5 @@ sample=../Samples/1st Violins/1st-violins-col-c#7-pp.flac
 lokey=e6
 hikey=c7
 pitch_keycenter=c#7
-pan=10
+pan=25
 tune=9

--- a/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Pizzicato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Pizzicato.sfz
@@ -11,6 +11,7 @@ seq_length=2
 ampeg_sustain=0
 ampeg_decay=1
 ampeg_vel2decay=10
+width=50
 
 <region>
 sample=..\Samples\1st Violins\1st-violins-piz-rr1-g3.wav
@@ -106,6 +107,7 @@ transpose=-1
 ampeg_sustain=0
 ampeg_decay=1
 ampeg_vel2decay=10
+width=50
 
 <region>
 sample=..\Samples\1st Violins\1st-violins-piz-rr2-g3.wav

--- a/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Col Legno.sfz
@@ -14,7 +14,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-p.flac
 lokey=g3
 hikey=a#3
 pitch_keycenter=g3
-pan=-3
+pan=-8
 tune=-5
 
 <region>
@@ -22,7 +22,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-pp.flac
 lokey=g3
 hikey=b3
 pitch_keycenter=g3
-pan=-10
+pan=-25
 tune=-13
 
 <region>
@@ -30,7 +30,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#3-p.flac
 lokey=g3
 hikey=c#4
 pitch_keycenter=a#3
-pan=-3
+pan=-8
 tune=3
 
 <region>
@@ -38,7 +38,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-p.flac
 lokey=g3
 hikey=d#4
 pitch_keycenter=c#4
-pan=10
+pan=25
 tune=23
 
 <region>
@@ -46,7 +46,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-pp.flac
 lokey=b3
 hikey=d#4
 pitch_keycenter=c#4
-pan=3
+pan=8
 tune=9
 
 <region>
@@ -54,7 +54,7 @@ sample=../Samples/1st Violins/1st-violins-col-d4-pp.flac
 lokey=c4
 hikey=d#4
 pitch_keycenter=d4
-pan=-10
+pan=-25
 tune=0
 
 <region>
@@ -62,7 +62,7 @@ sample=../Samples/1st Violins/1st-violins-col-e4-p.flac
 lokey=d4
 hikey=f4
 pitch_keycenter=e4
-pan=10
+pan=25
 tune=-7
 
 <region>
@@ -70,7 +70,7 @@ sample=../Samples/1st Violins/1st-violins-col-e4-pp.flac
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
-pan=3
+pan=8
 tune=0
 
 <region>
@@ -78,7 +78,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-p.flac
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
-pan=-3
+pan=-8
 tune=-14
 
 <region>
@@ -86,7 +86,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-pp.flac
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
-pan=-10
+pan=-25
 tune=0
 
 <region>
@@ -94,7 +94,7 @@ sample=../Samples/1st Violins/1st-violins-col-f#4-p.flac
 lokey=f#4
 hikey=g4
 pitch_keycenter=f#4
-pan=10
+pan=25
 tune=-2
 
 <region>
@@ -102,7 +102,7 @@ sample=../Samples/1st Violins/1st-violins-col-f#4-pp.flac
 lokey=f#4
 hikey=g4
 pitch_keycenter=f#4
-pan=3
+pan=8
 tune=-17
 
 <region>
@@ -110,7 +110,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-p.flac
 lokey=g4
 hikey=g#4
 pitch_keycenter=g4
-pan=-3
+pan=-8
 tune=-2
 
 <region>
@@ -118,7 +118,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-pp.flac
 lokey=g4
 hikey=g#4
 pitch_keycenter=g4
-pan=-10
+pan=-25
 tune=-3
 
 <region>
@@ -126,7 +126,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#4-p.flac
 lokey=g#4
 hikey=b4
 pitch_keycenter=a#4
-pan=10
+pan=25
 tune=-26
 
 <region>
@@ -134,7 +134,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#4-p2.flac
 lokey=g#4
 hikey=b4
 pitch_keycenter=a#4
-pan=3
+pan=8
 tune=-8
 
 <region>
@@ -142,7 +142,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-p.flac
 lokey=a4
 hikey=c5
 pitch_keycenter=b4
-pan=-3
+pan=-8
 tune=6
 
 <region>
@@ -150,7 +150,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-pp.flac
 lokey=a4
 hikey=c5
 pitch_keycenter=b4
-pan=-10
+pan=-25
 tune=-5
 
 <region>
@@ -158,7 +158,7 @@ sample=../Samples/1st Violins/1st-violins-col-c5-p.flac
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
-pan=10
+pan=25
 tune=9
 
 <region>
@@ -166,7 +166,7 @@ sample=../Samples/1st Violins/1st-violins-col-c5-pp.flac
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
-pan=3
+pan=8
 tune=53
 
 <region>
@@ -174,7 +174,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-p.flac
 lokey=c#5
 hikey=e5
 pitch_keycenter=d#5
-pan=-3
+pan=-8
 tune=-21
 
 <region>
@@ -182,7 +182,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-pp.flac
 lokey=c#5
 hikey=e5
 pitch_keycenter=d#5
-pan=-10
+pan=-25
 tune=4
 
 <region>
@@ -190,7 +190,7 @@ sample=../Samples/1st Violins/1st-violins-col-e5-p.flac
 lokey=d5
 hikey=f#5
 pitch_keycenter=e5
-pan=10
+pan=25
 tune=5
 
 <region>
@@ -198,7 +198,7 @@ sample=../Samples/1st Violins/1st-violins-col-e5-pp.flac
 lokey=d5
 hikey=f#5
 pitch_keycenter=e5
-pan=3
+pan=8
 tune=-10
 
 <region>
@@ -206,7 +206,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-p.flac
 lokey=f5
 hikey=a5
 pitch_keycenter=g#5
-pan=-3
+pan=-8
 tune=-5
 
 <region>
@@ -214,7 +214,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-pp.flac
 lokey=f5
 hikey=a5
 pitch_keycenter=g#5
-pan=-10
+pan=-25
 tune=-11
 
 <region>
@@ -222,7 +222,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#5-p.flac
 lokey=g5
 hikey=b5
 pitch_keycenter=a#5
-pan=10
+pan=25
 tune=0
 
 <region>
@@ -230,7 +230,7 @@ sample=../Samples/1st Violins/1st-violins-col-a#5-pp.flac
 lokey=g5
 hikey=b5
 pitch_keycenter=a#5
-pan=3
+pan=8
 tune=17
 
 <region>
@@ -238,7 +238,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-p.flac
 lokey=a#5
 hikey=d#6
 pitch_keycenter=b5
-pan=-3
+pan=-8
 tune=0
 
 <region>
@@ -246,7 +246,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-pp.flac
 lokey=a#5
 hikey=d#6
 pitch_keycenter=b5
-pan=-10
+pan=-25
 tune=0
 
 <region>
@@ -254,7 +254,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#6-p.flac
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
-pan=10
+pan=25
 tune=9
 
 <region>
@@ -262,7 +262,7 @@ sample=../Samples/1st Violins/1st-violins-col-d6-pp.flac
 lokey=c6
 hikey=c7
 pitch_keycenter=d6
-pan=3
+pan=8
 tune=-25
 
 <region>
@@ -270,7 +270,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#6-p.flac
 lokey=d#6
 hikey=c7
 pitch_keycenter=d#6
-pan=10
+pan=25
 tune=27
 
 <region>
@@ -278,7 +278,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#6-p.flac
 lokey=e6
 hikey=c7
 pitch_keycenter=g#6
-pan=-3
+pan=-8
 tune=-36
 
 <region>
@@ -286,5 +286,5 @@ sample=../Samples/1st Violins/1st-violins-col-c#7-pp.flac
 lokey=e6
 hikey=c7
 pitch_keycenter=c#7
-pan=-10
+pan=-25
 tune=9

--- a/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Pizzicato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Pizzicato.sfz
@@ -11,6 +11,7 @@ seq_length=2
 ampeg_sustain=0
 ampeg_decay=1
 ampeg_vel2decay=10
+width=50
 
 <region>
 sample=..\Samples\2nd Violins\2nd-violins-piz-rr1-g3.wav
@@ -106,6 +107,7 @@ transpose=-1
 ampeg_sustain=0
 ampeg_decay=1
 ampeg_vel2decay=10
+width=50
 
 <region>
 sample=..\Samples\2nd Violins\2nd-violins-piz-rr2-g3.wav

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Basses Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Basses Col Legno.sfz
@@ -19,7 +19,7 @@ lokey=c1
 hikey=g1
 tune=-26
 volume=-2
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-f1.flac
@@ -28,7 +28,7 @@ lokey=c1
 hikey=a1
 tune=-13
 volume=5
-pan=7
+pan=20
 
 <region>
 sample=../Samples/Basses/basses-col-a#1.flac
@@ -37,7 +37,7 @@ lokey=g#1
 hikey=d2
 tune=-8
 volume=1
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-d2.flac
@@ -46,7 +46,7 @@ lokey=a#1
 hikey=e2
 tune=-48
 volume=0
-pan=7
+pan=20
 
 <region>
 sample=../Samples/Basses/basses-col-g2.flac
@@ -55,7 +55,7 @@ lokey=d#2
 hikey=g2
 tune=-42
 volume=0
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-g2-2.flac
@@ -63,7 +63,7 @@ pitch_keycenter=g2
 lokey=f2
 hikey=g#2
 volume=0
-pan=7
+pan=20
 
 <region>
 sample=../Samples/Basses/basses-col-g#2.flac
@@ -72,7 +72,7 @@ lokey=g#2
 hikey=a#2
 tune=-23
 volume=0
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-a2.flac
@@ -81,7 +81,7 @@ lokey=a2
 hikey=c#3
 tune=-25
 volume=-2
-pan=7
+pan=20
 
 <region>
 sample=../Samples/Basses/basses-col-c#3.flac
@@ -90,7 +90,7 @@ lokey=b2
 hikey=a3
 tune=-36
 volume=0
-pan=-7
+pan=-20
 
 <region>
 sample=../Samples/Basses/basses-col-f#3.flac
@@ -99,7 +99,7 @@ lokey=d3
 hikey=a3
 tune=-39
 volume=2
-pan=7
+pan=20
 
 
 // Borrowed cello samples

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Celli Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Celli Col Legno.sfz
@@ -17,7 +17,7 @@ sample=../Samples/Celli/celli-col-c2.flac
 pitch_keycenter=c2
 lokey=c2
 hikey=d#2
-pan=-10
+pan=-25
 tune=10
 volume=1
 
@@ -26,7 +26,7 @@ sample=../Samples/Celli/celli-col-c#2.flac
 pitch_keycenter=c#2
 lokey=c2
 hikey=e2
-pan=-3
+pan=-8
 tune=8
 volume=-2
 
@@ -35,7 +35,7 @@ sample=../Samples/Celli/celli-col-d#2.flac
 pitch_keycenter=d#2
 lokey=c2
 hikey=f#2
-pan=10
+pan=25
 tune=11
 volume=2
 
@@ -44,7 +44,7 @@ sample=../Samples/Celli/celli-col-f#2.flac
 pitch_keycenter=f#2
 lokey=e2
 hikey=g#2
-pan=-10
+pan=-25
 tune=-30
 volume=-1
 
@@ -53,7 +53,7 @@ sample=../Samples/Celli/celli-col-g2.flac
 pitch_keycenter=g2
 lokey=f2
 hikey=a2
-pan=-3
+pan=-8
 tune=15
 volume=-2
 
@@ -62,7 +62,7 @@ sample=../Samples/Celli/celli-col-a2.flac
 pitch_keycenter=a2
 lokey=g2
 hikey=a#2
-pan=10
+pan=25
 tune=-1
 volume=0
 
@@ -71,7 +71,7 @@ sample=../Samples/Celli/celli-col-a#2.flac
 pitch_keycenter=a#2
 lokey=a2
 hikey=c#3
-pan=-10
+pan=-25
 tune=29
 volume=3
 
@@ -80,7 +80,7 @@ sample=../Samples/Celli/celli-col-b2.flac
 pitch_keycenter=b2
 lokey=a#2
 hikey=d3
-pan=-3
+pan=-8
 volume=-1
 
 <region>
@@ -88,7 +88,7 @@ sample=../Samples/Celli/celli-col-c3.flac
 pitch_keycenter=c3
 lokey=b2
 hikey=d#3
-pan=10
+pan=25
 tune=-5
 volume=1
 
@@ -97,7 +97,7 @@ sample=../Samples/Celli/celli-col-e3.flac
 pitch_keycenter=e3
 lokey=d3
 hikey=f#3
-pan=-10
+pan=-25
 volume=-3
 
 <region>
@@ -105,7 +105,7 @@ sample=../Samples/Celli/celli-col-f3.flac
 pitch_keycenter=f3
 lokey=d#3
 hikey=g3
-pan=-3
+pan=-8
 tune=7
 volume=1
 
@@ -114,7 +114,7 @@ sample=../Samples/Celli/celli-col-f#3.flac
 pitch_keycenter=f#3
 lokey=e3
 hikey=a#3
-pan=10
+pan=25
 tune=26
 volume=0
 
@@ -123,7 +123,7 @@ sample=../Samples/Celli/celli-col-g#3.flac
 pitch_keycenter=g#3
 lokey=g3
 hikey=b3
-pan=-10
+pan=-25
 tune=-11
 volume=2
 
@@ -132,7 +132,7 @@ sample=../Samples/Celli/celli-col-a3.flac
 pitch_keycenter=a3
 lokey=g#3
 hikey=d4
-pan=-3
+pan=-8
 tune=-3
 volume=0
 
@@ -141,7 +141,7 @@ sample=../Samples/Celli/celli-col-c#4.flac
 pitch_keycenter=c#4
 lokey=b3
 hikey=g4
-pan=10
+pan=25
 volume=0
 
 <region>
@@ -149,7 +149,7 @@ sample=../Samples/Celli/celli-col-d#4.flac
 pitch_keycenter=d#4
 lokey=c4
 hikey=g4
-pan=-10
+pan=-25
 tune=-21
 volume=1
 
@@ -158,7 +158,7 @@ sample=../Samples/Celli/celli-col-g4.flac
 pitch_keycenter=g4
 lokey=d#4
 hikey=d5
-pan=-3
+pan=-8
 volume=1
 
 <region>
@@ -166,7 +166,7 @@ sample=../Samples/Celli/celli-col-d5.flac
 pitch_keycenter=d5
 lokey=g#4
 hikey=d5
-pan=10
+pan=25
 tune=-33
 volume=-1
 
@@ -179,7 +179,7 @@ sample=../Samples/Basses/basses-col-f1.flac
 pitch_keycenter=f1
 lokey=c2
 hikey=d2
-pan=3
+pan=8
 tune=-13
 volume=5
 
@@ -188,7 +188,7 @@ sample=../Samples/Basses/basses-col-a#1.flac
 pitch_keycenter=a#1
 lokey=d#2
 hikey=f#2
-pan=3
+pan=8
 tune=-8
 volume=1
 
@@ -197,7 +197,7 @@ sample=../Samples/Basses/basses-col-d2.flac
 pitch_keycenter=d2
 lokey=g2
 hikey=b2
-pan=3
+pan=8
 tune=-48
 volume=0
 
@@ -206,7 +206,7 @@ sample=../Samples/Basses/basses-col-g2.flac
 pitch_keycenter=g2
 lokey=c3
 hikey=d3
-pan=3
+pan=8
 volume=0
 tune=-42
 
@@ -215,7 +215,7 @@ sample=../Samples/Basses/basses-col-a2.flac
 pitch_keycenter=a2
 lokey=d#3
 hikey=g3
-pan=3
+pan=8
 tune=-25
 volume=-2
 
@@ -228,7 +228,7 @@ sample=../Samples/Violas/violas-col-e4.flac
 pitch_keycenter=e4
 lokey=g#3
 hikey=b3
-pan=3
+pan=8
 volume=-4
 
 <region>
@@ -236,7 +236,7 @@ sample=../Samples/Violas/violas-col-a4.flac
 pitch_keycenter=a4
 lokey=c4
 hikey=e4
-pan=3
+pan=8
 volume=-1
 
 <region>
@@ -244,5 +244,5 @@ sample=../Samples/Violas/violas-col-d5.flac
 pitch_keycenter=d5
 lokey=f4
 hikey=d5
-pan=3
+pan=8
 volume=0

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Violas Col Legno.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Violas Col Legno.sfz
@@ -16,7 +16,7 @@ sample=../Samples/Violas/violas-col-c3.flac
 pitch_keycenter=c3
 lokey=c3
 hikey=e3
-pan=-10
+pan=-25
 tune=11
 volume=0
 
@@ -25,7 +25,7 @@ sample=../Samples/Violas/violas-col-f#3.flac
 pitch_keycenter=f#3
 lokey=c3
 hikey=g3
-pan=10
+pan=25
 tune=21
 volume=0
 
@@ -34,7 +34,7 @@ sample=../Samples/Violas/violas-col-g3.flac
 pitch_keycenter=g3
 lokey=f3
 hikey=g3
-pan=-10
+pan=-25
 tune=1
 volume=0
 
@@ -43,7 +43,7 @@ sample=../Samples/Violas/violas-col-g#3.flac
 pitch_keycenter=g#3
 lokey=g#3
 hikey=a3
-pan=10
+pan=25
 tune=30
 volume=1
 
@@ -52,7 +52,7 @@ sample=../Samples/Violas/violas-col-a3.flac
 pitch_keycenter=a3
 lokey=g#3
 hikey=b3
-pan=-10
+pan=-25
 tune=-34
 volume=0
 
@@ -61,7 +61,7 @@ sample=../Samples/Violas/violas-col-b3.flac
 pitch_keycenter=b3
 lokey=a#3
 hikey=c#4
-pan=10
+pan=25
 tune=-17
 volume=-2
 
@@ -70,7 +70,7 @@ sample=../Samples/Violas/violas-col-c4.flac
 pitch_keycenter=c4
 lokey=c4
 hikey=d#4
-pan=-10
+pan=-25
 tune=-4
 volume=1
 
@@ -79,7 +79,7 @@ sample=../Samples/Violas/violas-col-e4.flac
 pitch_keycenter=e4
 lokey=d4
 hikey=g4
-pan=10
+pan=25
 volume=-4
 
 <region>
@@ -87,7 +87,7 @@ sample=../Samples/Violas/violas-col-g4.flac
 pitch_keycenter=g4
 lokey=e4
 hikey=a#4
-pan=-10
+pan=-25
 volume=5
 
 <region>
@@ -95,7 +95,7 @@ sample=../Samples/Violas/violas-col-a4.flac
 pitch_keycenter=a4
 lokey=g#4
 hikey=d5
-pan=10
+pan=25
 volume=-1
 
 <region>
@@ -103,7 +103,7 @@ sample=../Samples/Violas/violas-col-d5.flac
 pitch_keycenter=d5
 lokey=b4
 hikey=a5
-pan=-10
+pan=-25
 volume=0
 
 <region>
@@ -111,7 +111,7 @@ sample=../Samples/Violas/violas-col-f#5.flac
 pitch_keycenter=f#5
 lokey=d#5
 hikey=c6
-pan=10
+pan=25
 volume=1
 
 // Borrowed violin samples
@@ -121,7 +121,7 @@ sample=../Samples/1st Violins/1st-violins-col-g3-p.flac
 lokey=c3
 hikey=d#3
 pitch_keycenter=g3
-pan=-3
+pan=-8
 tune=-5
 
 <region>
@@ -129,7 +129,7 @@ sample=../Samples/1st Violins/1st-violins-col-c#4-pp.flac
 lokey=e3
 hikey=g#3
 pitch_keycenter=c#4
-pan=-3
+pan=-8
 tune=9
 
 <region>
@@ -137,7 +137,7 @@ sample=../Samples/1st Violins/1st-violins-col-f4-p.flac
 lokey=a3
 hikey=b3
 pitch_keycenter=f4
-pan=-3
+pan=-8
 tune=-14
 
 <region>
@@ -145,7 +145,7 @@ sample=../Samples/1st Violins/1st-violins-col-g4-p.flac
 lokey=c4
 hikey=c#4
 pitch_keycenter=g4
-pan=-3
+pan=-8
 tune=-2
 
 <region>
@@ -153,7 +153,7 @@ sample=../Samples/1st Violins/1st-violins-col-b4-p.flac
 lokey=d4
 hikey=f4
 pitch_keycenter=b4
-pan=-3
+pan=-8
 tune=6
 
 <region>
@@ -161,7 +161,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#5-p.flac
 lokey=f#4
 hikey=a4
 pitch_keycenter=d#5
-pan=-3
+pan=-8
 tune=-21
 
 <region>
@@ -169,7 +169,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#5-p.flac
 lokey=a#4
 hikey=d5
 pitch_keycenter=g#5
-pan=-3
+pan=-8
 tune=-5
 
 <region>
@@ -177,7 +177,7 @@ sample=../Samples/1st Violins/1st-violins-col-b5-p.flac
 lokey=d#5
 hikey=g5
 pitch_keycenter=b5
-pan=-3
+pan=-8
 tune=0
 
 <region>
@@ -185,7 +185,7 @@ sample=../Samples/1st Violins/1st-violins-col-d#6-p.flac
 lokey=g#5
 hikey=c6
 pitch_keycenter=d#6
-pan=-3
+pan=-8
 tune=27
 
 <region>
@@ -193,7 +193,7 @@ sample=../Samples/1st Violins/1st-violins-col-g#6-p.flac
 lokey=a#5
 hikey=c6
 pitch_keycenter=g#6
-pan=-3
+pan=-8
 tune=-36
 
 // Borrowed cello samples
@@ -203,7 +203,7 @@ sample=../Samples/Celli/celli-col-f#2.flac
 pitch_keycenter=f#2
 lokey=c3
 hikey=d3
-pan=3
+pan=8
 tune=-30
 volume=-1
 
@@ -212,7 +212,7 @@ sample=../Samples/Celli/celli-col-a#2.flac
 pitch_keycenter=a#2
 lokey=d#3
 hikey=g#3
-pan=3
+pan=8
 tune=29
 volume=3
 
@@ -221,7 +221,7 @@ sample=../Samples/Celli/celli-col-e3.flac
 pitch_keycenter=e3
 lokey=a3
 hikey=c#4
-pan=3
+pan=8
 volume=-3
 
 <region>
@@ -229,7 +229,7 @@ sample=../Samples/Celli/celli-col-a3.flac
 pitch_keycenter=a3
 lokey=d4
 hikey=f#4
-pan=3
+pan=8
 tune=-3
 volume=0
 
@@ -238,7 +238,7 @@ sample=../Samples/Celli/celli-col-d#4.flac
 pitch_keycenter=d#4
 lokey=g4
 hikey=b4
-pan=3
+pan=8
 tune=-21
 volume=1
 
@@ -247,7 +247,7 @@ sample=../Samples/Celli/celli-col-g4.flac
 pitch_keycenter=g4
 lokey=c5
 hikey=f#5
-pan=3
+pan=8
 volume=1
 
 <region>
@@ -255,6 +255,6 @@ sample=../Samples/Celli/celli-col-d5.flac
 pitch_keycenter=d5
 lokey=g5
 hikey=c6
-pan=3
+pan=8
 tune=-33
 volume=-1


### PR DESCRIPTION
The col legno articulations had less stereo width than the others.  I increased it.

For the violins, the pizzicato samples had more width than the others, so I narrowed them.

This makes the different articulations sound more like they come from the same instruments.