### PR TITLE
Vibrato for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Most solo instruments have three versions:
   on how long any note can be held.
 - A looped version that can be held indefinitely, but sounds less natural than the non-looped version.
 - A looped version that adds a gradual decay and gentle modulation.  This tries to give a more natural sound than the
-  simple looped version, but still not place a strict limit on how long notes can be held.
+  simple looped version, but still not place a strict limit on how long notes can be held.  If you are in doubt about
+  which version to use, this is usually the best choice.
 
 There are two different solo violin instruments, and likewise two different solo flutes.  In each case, one of the two
 instruments has more articulations, but does not offer a looped version.
@@ -141,6 +142,8 @@ Many instruments are provided in separate "notation" and "performance" versions.
   - Marcato articulations use the mod wheel to set the overall volume and velocity to control the strength of the
     initial attack.
   - Short articulations use velocity to set the volume.
+
+In both control systems, MIDI control channel 21 controls the amount of vibrato in string instruments.
 
 Here are definitions of the most common articulations.
 

--- a/README.md
+++ b/README.md
@@ -134,16 +134,16 @@ Many instruments are provided in separate "notation" and "performance" versions.
 
 - Notation instruments use a control system convenient for use in notation programs.
   - All instruments use velocity to set the volume.
-  - Marcato articulations use the mod wheel (MIDI control channel 1) to adjust the strength of the initial attack.  This
+  - Marcato articulations use the mod wheel (MIDI CC 1) to adjust the strength of the initial attack.  This
     lets you smoothly blend between a gentle sustain and a strong marcato.
 - Performance instruments are better for use in live performance.
-  - Long articulations use the mod wheel (MIDI control channel 1) to set the volume.  This allows you to continuously
+  - Long articulations use the mod wheel (MIDI CC 1) to set the volume.  This allows you to continuously
     shape each note.  Many long articulations also use velocity to control the attack rate.
   - Marcato articulations use the mod wheel to set the overall volume and velocity to control the strength of the
     initial attack.
   - Short articulations use velocity to set the volume.
 
-In both control systems, MIDI control channel 21 controls the amount of vibrato in string instruments.
+In both control systems, MIDI CC 21 controls the amount of vibrato in string instruments.
 
 Here are definitions of the most common articulations.
 

--- a/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Harmonics.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Harmonics.sfz
@@ -4,6 +4,10 @@
 //     1st Violins Harmonics
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.375
 ampeg_vel2attack=-0.175
@@ -13,6 +17,10 @@ cutoff=1100
 fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
+
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 
 <region>
 sample=../Samples/1st Violins/1st-violins-hrm-g3.flac

--- a/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.30
 ampeg_vel2attack=-0.180
@@ -21,6 +25,9 @@ off_time=1
 trigger=first
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/1st-violins-sustain.sfz"
 
 <group>
@@ -39,4 +46,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/1st-violins-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Marcato.sfz
@@ -4,6 +4,10 @@
 //      1st Violins Marcato
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 // -------
 // Sustain
 // -------
@@ -18,6 +22,9 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/1st-violins-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/1st Violins Sustain.sfz
@@ -4,6 +4,10 @@
 //      1st Violins Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.180
 ampeg_vel2attack=-0.180
@@ -14,4 +18,7 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/1st-violins-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Harmonics.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Harmonics.sfz
@@ -4,8 +4,11 @@
 //     2nd Violins Harmonics
 // ------------------------------
 
-<group>
+<control>
+label_cc21=Vibrato
+set_cc21=0
 
+<group>
 ampeg_attack=0.375
 ampeg_vel2attack=-0.175
 ampeg_release=1
@@ -14,6 +17,10 @@ cutoff=1100
 fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
+
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 
 <region>
 sample=../Samples/2nd Violins/2nd-violins-hrm-g3.flac

--- a/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.30
 ampeg_vel2attack=-0.175
@@ -21,6 +25,9 @@ off_time=1
 trigger=first
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/2nd-violins-sustain.sfz"
 
 <group>
@@ -39,4 +46,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/2nd-violins-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
+
 // -------
 // Sustain
 // -------
@@ -19,6 +24,9 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/2nd-violins-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/2nd Violins Sustain.sfz
@@ -4,6 +4,10 @@
 //      2nd Violins Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.175
 ampeg_vel2attack=-0.175
@@ -14,4 +18,7 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/2nd-violins-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Bass Solo Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Bass Solo Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
 <group>
 loop_mode=loop_continuous
 ampeg_attack=0.8
@@ -21,6 +25,9 @@ off_mode=time
 off_time=1
 trigger=first
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/bass-solo-sustain.sfz"
 
 <group>
@@ -39,4 +46,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/bass-solo-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Bass Solo Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Bass Solo Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
+
 // -------
 // Sustain
 // -------
@@ -20,6 +25,9 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/bass-solo-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Bass Solo Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Bass Solo Sustain.sfz
@@ -4,6 +4,10 @@
 //          Bass Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
 <group>
 loop_mode=loop_continuous
 ampeg_attack=0.8
@@ -15,4 +19,7 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/bass-solo-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Basses Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Basses Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.30
 ampeg_vel2attack=-0.300
@@ -21,6 +25,9 @@ off_time=1
 trigger=first
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/basses-sustain.sfz"
 
 <group>
@@ -38,4 +45,7 @@ off_time=1
 trigger=legato
 offset=30000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/basses-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Basses Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Basses Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
+
 // -------
 // Sustain
 // -------
@@ -19,6 +24,9 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/basses-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Basses Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Basses Sustain.sfz
@@ -4,6 +4,10 @@
 //        Basses Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.300
 ampeg_vel2attack=-0.300
@@ -14,4 +18,7 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/basses-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Basses Tremolo.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Basses Tremolo.sfz
@@ -17,64 +17,64 @@ fil_keytrack=100
 
 <region>
 sample=../Samples/Basses/basses-trm-c1.flac
-loop_start=105662
-loop_end=318395
+loop_start=104521
+loop_end=315147
 lokey=c1
 hikey=c#1
 pitch_keycenter=c1
 
 <region>
 sample=../Samples/Basses/basses-trm-d#1.flac
-loop_start=105530
-loop_end=316898
+loop_start=107984
+loop_end=322974
 lokey=d1
 hikey=e1
 pitch_keycenter=d#1
 
 <region>
 sample=../Samples/Basses/basses-trm-f#1.flac
-loop_start=106407
-loop_end=319188
+loop_start=105092
+loop_end=316372
 lokey=f1
 hikey=g1
 pitch_keycenter=f#1
 
 <region>
 sample=../Samples/Basses/basses-trm-a1.flac
-loop_start=104824
-loop_end=313838
+loop_start=105901
+loop_end=316733
 lokey=g#1
 hikey=a#1
 pitch_keycenter=a1
 
 <region>
 sample=../Samples/Basses/basses-trm-c2.flac
-loop_start=105974
-loop_end=316655
+loop_start=104447
+loop_end=313420
 lokey=b1
 hikey=c#2
 pitch_keycenter=c2
 
 <region>
 sample=../Samples/Basses/basses-trm-d#2.flac
-loop_start=105955
-loop_end=318521
+loop_start=107151
+loop_end=319827
 lokey=d2
 hikey=e2
 pitch_keycenter=d#2
 
 <region>
 sample=../Samples/Basses/basses-trm-f#2.flac
-loop_start=106074
-loop_end=317290
+loop_start=106980
+loop_end=320536
 lokey=f2
 hikey=g2
 pitch_keycenter=f#2
 
 <region>
 sample=../Samples/Basses/basses-trm-a2.flac
-loop_start=106579
-loop_end=318404
+loop_start=106561
+loop_end=319919
 lokey=g#2
 hikey=a#2
 pitch_keycenter=a2
@@ -82,16 +82,16 @@ volume=-2
 
 <region>
 sample=../Samples/Basses/basses-trm-c3.flac
-loop_start=106108
-loop_end=319910
+loop_start=106866
+loop_end=320643
 lokey=b2
 hikey=c#3
 pitch_keycenter=c3
 
 <region>
 sample=../Samples/Basses/basses-trm-d#3.flac
-loop_start=106131
-loop_end=321098
+loop_start=103970
+loop_end=314285
 lokey=d3
 hikey=e3
 pitch_keycenter=d#3
@@ -99,8 +99,8 @@ volume=-2
 
 <region>
 sample=../Samples/Basses/basses-trm-f#3.flac
-loop_start=105341
-loop_end=316931
+loop_start=105981
+loop_end=318361
 lokey=f3
 hikey=g3
 pitch_keycenter=f#3
@@ -108,8 +108,8 @@ volume=1
 
 <region>
 sample=../Samples/Basses/basses-trm-a3.flac
-loop_start=104284
-loop_end=313680
+loop_start=108101
+loop_end=319544
 lokey=g#3
 hikey=a#3
 pitch_keycenter=a3
@@ -117,8 +117,8 @@ volume=-1
 
 <region>
 sample=../Samples/Basses/basses-trm-c4.flac
-loop_start=105594
-loop_end=317075
+loop_start=105081
+loop_end=315855
 lokey=b3
 hikey=c4
 pitch_keycenter=c4

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Celli Harmonics.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Celli Harmonics.sfz
@@ -4,6 +4,10 @@
 //        Celli Harmonics
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.500
 ampeg_vel2attack=-0.300
@@ -15,6 +19,10 @@ cutoff=1500
 fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
+
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 
 <region>
 sample=../Samples/Celli/celli-hrm-c2.flac

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Celli Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Celli Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.30
 ampeg_vel2attack=-0.300
@@ -22,6 +26,9 @@ off_mode=time
 off_time=1
 trigger=first
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/celli-sustain.sfz"
 
 <group>
@@ -41,4 +48,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/celli-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Celli Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Celli Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
+
 // -------
 // Sustain
 // -------
@@ -21,6 +26,9 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/celli-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Celli Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Celli Sustain.sfz
@@ -4,6 +4,10 @@
 //         Celli Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.300
 ampeg_vel2attack=-0.300
@@ -16,4 +20,7 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/celli-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Celli Tremolo.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Celli Tremolo.sfz
@@ -19,24 +19,24 @@ fil_keytrack=100
 
 <region>
 sample=../Samples/Celli/celli-trm-c2.flac
-loop_start=92838
-loop_end=278154
+loop_start=94288
+loop_end=281808
 lokey=c2
 hikey=c#2
 pitch_keycenter=c2
 
 <region>
 sample=../Samples/Celli/celli-trm-d#2.flac
-loop_start=92615
-loop_end=277738
+loop_start=94538
+loop_end=282649
 lokey=d2
 hikey=e2
 pitch_keycenter=d#2
 
 <region>
 sample=../Samples/Celli/celli-trm-f#2.flac
-loop_start=93538
-loop_end=278880
+loop_start=93024
+loop_end=277792
 lokey=f2
 hikey=g2
 pitch_keycenter=f#2
@@ -44,40 +44,40 @@ volume=1
 
 <region>
 sample=../Samples/Celli/celli-trm-a2.flac
-loop_start=91701
-loop_end=276144
+loop_start=93275
+loop_end=279643
 lokey=g#2
 hikey=a#2
 pitch_keycenter=a2
 
 <region>
 sample=../Samples/Celli/celli-trm-c3.flac
-loop_start=92705
-loop_end=276773
+loop_start=91542
+loop_end=276214
 lokey=b2
 hikey=c#3
 pitch_keycenter=c3
 
 <region>
 sample=../Samples/Celli/celli-trm-d#3.flac
-loop_start=92498
-loop_end=276627
+loop_start=92591
+loop_end=277582
 lokey=d3
 hikey=e3
 pitch_keycenter=d#3
 
 <region>
 sample=../Samples/Celli/celli-trm-f#3.flac
-loop_start=92884
-loop_end=280107
+loop_start=93607
+loop_end=280079
 lokey=f3
 hikey=g3
 pitch_keycenter=f#3
 
 <region>
 sample=../Samples/Celli/celli-trm-a3.flac
-loop_start=91824
-loop_end=277288
+loop_start=93387
+loop_end=278475
 lokey=g#3
 hikey=a#3
 pitch_keycenter=a3
@@ -85,16 +85,16 @@ volume=-3
 
 <region>
 sample=../Samples/Celli/celli-trm-c4.flac
-loop_start=94081
-loop_end=280351
+loop_start=92477
+loop_end=276145
 lokey=b3
 hikey=c#4
 volume=-2
 
 <region>
 sample=../Samples/Celli/celli-trm-d#4.flac
-loop_start=91415
-loop_end=274960
+loop_start=93290
+loop_end=278763
 lokey=d4
 hikey=e4
 pitch_keycenter=d#4
@@ -102,8 +102,8 @@ volume=-2
 
 <region>
 sample=../Samples/Celli/celli-trm-f#4.flac
-loop_start=92528
-loop_end=277950
+loop_start=92317
+loop_end=277414
 lokey=f4
 hikey=g4
 pitch_keycenter=f#4
@@ -111,8 +111,8 @@ volume=2
 
 <region>
 sample=../Samples/Celli/celli-trm-a4.flac
-loop_start=92965
-loop_end=279213
+loop_start=91778
+loop_end=275402
 lokey=g#4
 hikey=a#4
 pitch_keycenter=a4
@@ -120,11 +120,8 @@ volume=-3
 
 <region>
 sample=../Samples/Celli/celli-trm-c5.flac
-loop_start=91895
-loop_end=276324
+loop_start=92975
+loop_end=277627
 lokey=b4
 hikey=c#5
 pitch_keycenter=c5
-
-
-

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Viola Solo Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Viola Solo Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
 <group>
 loop_mode=loop_continuous
 ampeg_attack=0.2
@@ -21,6 +25,9 @@ off_mode=time
 off_time=0.5
 trigger=first
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/viola-solo-sustain.sfz"
 
 <group>
@@ -39,4 +46,7 @@ off_time=0.5
 trigger=legato
 offset=40000
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/viola-solo-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Viola Solo Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Viola Solo Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
+
 // -------
 // Sustain
 // -------
@@ -20,6 +25,9 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/viola-solo-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Viola Solo Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Viola Solo Sustain.sfz
@@ -4,6 +4,10 @@
 //         Viola Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
 <group>
 loop_mode=loop_continuous
 ampeg_attack=0.2
@@ -15,4 +19,7 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/viola-solo-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Violas Harmonics.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Violas Harmonics.sfz
@@ -4,6 +4,10 @@
 //       Violas Harmonics
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.180
 ampeg_release=1.15
@@ -12,6 +16,10 @@ cutoff=1100
 fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
+
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 
 <region>
 sample=../Samples/Violas/violas-hrm-c3.flac

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Violas Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Violas Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_release=1.15
 fil_type=lpf_1p
@@ -18,6 +22,9 @@ off_mode=time
 off_time=1
 trigger=first
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/violas-sustain.sfz"
 
 <group>
@@ -35,4 +42,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/violas-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Violas Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Violas Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
+
 // -------
 // Sustain
 // -------
@@ -17,6 +22,9 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/violas-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Violas Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Violas Sustain.sfz
@@ -4,6 +4,10 @@
 //        Violas Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_release=1.15
 fil_type=lpf_1p
@@ -12,4 +16,7 @@ fil_veltrack=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/violas-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Notation/Violas Tremolo.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/Violas Tremolo.sfz
@@ -15,47 +15,47 @@ fil_keytrack=100
 
 <region>
 sample=../Samples/Violas/violas-trm-c3.flac
-loop_start=65650
-loop_end=242126
+loop_start=66669
+loop_end=244408
 lokey=c3
 hikey=c#3
 pitch_keycenter=c3
 
 <region>
 sample=../Samples/Violas/violas-trm-d#3.flac
-loop_start=68013
-loop_end=246537
+loop_start=66034
+loop_end=242534
 lokey=d3
 hikey=e3
 pitch_keycenter=d#3
 
 <region>
 sample=../Samples/Violas/violas-trm-f#3.flac
-loop_start=65491
-loop_end=240105
+loop_start=66867
+loop_end=243276
 lokey=f3
 hikey=g3
 pitch_keycenter=f#3
 
 <region>
 sample=../Samples/Violas/violas-trm-a3.flac
-loop_start=65880
-loop_end=239727
+loop_start=66475
+loop_end=242722
 lokey=g#3
 hikey=a#3
 pitch_keycenter=a3
 
 <region>
 sample=../Samples/Violas/violas-trm-c4.flac
-loop_start=66467
-loop_end=242598
+loop_start=66708
+loop_end=242614
 lokey=b3
 hikey=c#4
 
 <region>
 sample=../Samples/Violas/violas-trm-d#4.flac
-loop_start=67162
-loop_end=245193
+loop_start=66723
+loop_end=243837
 lokey=d4
 hikey=e4
 pitch_keycenter=d#4
@@ -63,8 +63,8 @@ volume=4
 
 <region>
 sample=../Samples/Violas/violas-trm-f#4.flac
-loop_start=66148
-loop_end=243699
+loop_start=67277
+loop_end=245906
 lokey=f4
 hikey=g4
 pitch_keycenter=f#4
@@ -72,8 +72,8 @@ volume=2
 
 <region>
 sample=../Samples/Violas/violas-trm-a4.flac
-loop_start=65593
-loop_end=242506
+loop_start=66499
+loop_end=244883
 lokey=g#4
 hikey=a#4
 pitch_keycenter=a4
@@ -81,8 +81,8 @@ volume=-1
 
 <region>
 sample=../Samples/Violas/violas-trm-c5.flac
-loop_start=66339
-loop_end=243879
+loop_start=67284
+loop_end=246287
 lokey=b4
 hikey=c#5
 pitch_keycenter=c5
@@ -90,24 +90,24 @@ volume=2
 
 <region>
 sample=../Samples/Violas/violas-trm-d#5.flac
-loop_start=65521
-loop_end=239643
+loop_start=66357
+loop_end=241746
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
 
 <region>
 sample=../Samples/Violas/violas-trm-f#5.flac
-loop_start=66549
-loop_end=243732
+loop_start=66219
+loop_end=242733
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
 
 <region>
 sample=../Samples/Violas/violas-trm-a5.flac
-loop_start=66523
-loop_end=242876
+loop_start=66736
+loop_end=242665
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
@@ -115,8 +115,8 @@ volume=-2
 
 <region>
 sample=../Samples/Violas/violas-trm-c6.flac
-loop_start=67948
-loop_end=247645
+loop_start=66383
+loop_end=243330
 lokey=b5
 hikey=c6
 pitch_keycenter=c6

--- a/Sonatina Symphonic Orchestra/Strings - Notation/includes/vibrato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/includes/vibrato.sfz
@@ -1,0 +1,23 @@
+// Use a LFO to modulate the pitch and volume based on CC 21.
+
+lfo01_pitch_oncc21=$VIB_PITCH
+lfo01_volume_oncc21=1
+lfo01_freq=5
+lfo01_freq_oncc21=2
+lfo01_delay=$VIB_DELAY
+lfo01_fade=0.5
+
+// Also vary the amount of high frequency harmonics.
+
+eq1_freq=2000
+eq1_bw=2
+lfo01_eq1gain_oncc21=3
+lfo01_eq1freq_oncc21=500
+
+// Using a complex waveform with multiple components gives a more natural sound.
+
+lfo01_wave=0
+lfo01_wave2=1
+lfo01_ratio2=0.48
+lfo01_offset2=0
+lfo01_scale2=0.2

--- a/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Harmonics.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Harmonics.sfz
@@ -4,6 +4,10 @@
 //     1st Violins Harmonics
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.375
 ampeg_vel2attack=-0.175
@@ -16,6 +20,10 @@ cutoff=1100
 cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
+
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 
 <region>
 sample=../Samples/1st Violins/1st-violins-hrm-g3.flac

--- a/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.30
 ampeg_vel2attack=-0.180
@@ -24,6 +28,9 @@ off_time=1
 trigger=first
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/1st-violins-sustain.sfz"
 
 <group>
@@ -45,4 +52,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/1st-violins-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Marcato.sfz
@@ -4,6 +4,10 @@
 //      1st Violins Marcato
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 // -------
 // Sustain
 // -------
@@ -21,6 +25,9 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/1st-violins-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/1st Violins Sustain.sfz
@@ -4,6 +4,10 @@
 //      1st Violins Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.180
 ampeg_vel2attack=-0.180
@@ -17,4 +21,7 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/1st-violins-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Harmonics.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Harmonics.sfz
@@ -4,8 +4,11 @@
 //     2nd Violins Harmonics
 // ------------------------------
 
-<group>
+<control>
+label_cc21=Vibrato
+set_cc21=0
 
+<group>
 ampeg_attack=0.375
 ampeg_vel2attack=-0.175
 ampeg_release=1
@@ -17,6 +20,10 @@ cutoff=1100
 cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
+
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 
 <region>
 sample=../Samples/2nd Violins/2nd-violins-hrm-g3.flac

--- a/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.30
 ampeg_vel2attack=-0.175
@@ -24,6 +28,9 @@ off_time=1
 trigger=first
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/2nd-violins-sustain.sfz"
 
 <group>
@@ -45,4 +52,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/2nd-violins-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
+
 // -------
 // Sustain
 // -------
@@ -22,6 +27,9 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/2nd-violins-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/2nd Violins Sustain.sfz
@@ -4,8 +4,11 @@
 //      2nd Violins Sustain
 // ------------------------------
 
-<group>
+<control>
+label_cc21=Vibrato
+set_cc21=0
 
+<group>
 ampeg_attack=0.175
 ampeg_vel2attack=-0.175
 ampeg_release=1
@@ -18,4 +21,7 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/2nd-violins-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Bass Solo Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Bass Solo Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
 <group>
 loop_mode=loop_continuous
 ampeg_attack=0.8
@@ -24,6 +28,9 @@ off_mode=time
 off_time=1
 trigger=first
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/bass-solo-sustain.sfz"
 
 <group>
@@ -45,4 +52,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/bass-solo-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Bass Solo Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Bass Solo Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
+
 // -------
 // Sustain
 // -------
@@ -23,6 +28,9 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/bass-solo-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Bass Solo Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Bass Solo Sustain.sfz
@@ -4,6 +4,10 @@
 //          Bass Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
 <group>
 loop_mode=loop_continuous
 ampeg_attack=0.8
@@ -18,4 +22,7 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/bass-solo-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Basses Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Basses Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.30
 ampeg_vel2attack=-0.300
@@ -24,6 +28,9 @@ off_time=1
 trigger=first
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/basses-sustain.sfz"
 
 <group>
@@ -44,4 +51,7 @@ off_time=1
 trigger=legato
 offset=30000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/basses-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Basses Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Basses Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
+
 // -------
 // Sustain
 // -------
@@ -22,6 +27,9 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/basses-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Basses Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Basses Sustain.sfz
@@ -4,6 +4,10 @@
 //        Basses Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.300
 ampeg_vel2attack=-0.300
@@ -17,4 +21,7 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/basses-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Celli Harmonics.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Celli Harmonics.sfz
@@ -4,6 +4,10 @@
 //        Celli Harmonics
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.500
 ampeg_vel2attack=-0.300
@@ -18,6 +22,10 @@ cutoff=1500
 cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
+
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 
 <region>
 sample=../Samples/Celli/celli-hrm-c2.flac

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Celli Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Celli Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.30
 ampeg_vel2attack=-0.300
@@ -25,6 +29,9 @@ off_mode=time
 off_time=1
 trigger=first
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/celli-sustain.sfz"
 
 <group>
@@ -47,4 +54,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/celli-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Celli Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Celli Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
+
 // -------
 // Sustain
 // -------
@@ -24,6 +29,9 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/celli-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Celli Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Celli Sustain.sfz
@@ -4,6 +4,10 @@
 //         Celli Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_attack=0.300
 ampeg_vel2attack=-0.300
@@ -19,4 +23,7 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/celli-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Viola Solo Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Viola Solo Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
 <group>
 loop_mode=loop_continuous
 ampeg_attack=0.2
@@ -24,6 +28,9 @@ off_mode=time
 off_time=0.5
 trigger=first
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/viola-solo-sustain.sfz"
 
 <group>
@@ -45,4 +52,7 @@ off_time=0.5
 trigger=legato
 offset=40000
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/viola-solo-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Viola Solo Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Viola Solo Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
+
 // -------
 // Sustain
 // -------
@@ -23,6 +28,9 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/viola-solo-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Viola Solo Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Viola Solo Sustain.sfz
@@ -4,6 +4,10 @@
 //         Viola Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=64
+
 <group>
 loop_mode=loop_continuous
 ampeg_attack=0.2
@@ -18,4 +22,7 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 35
+#define $VIB_DELAY 0.5
+#include "includes/vibrato.sfz"
 #include "includes/viola-solo-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Violas Legato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Violas Legato.sfz
@@ -5,6 +5,10 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_release=1.15
 amp_veltrack=0
@@ -21,6 +25,9 @@ off_mode=time
 off_time=1
 trigger=first
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/violas-sustain.sfz"
 
 <group>
@@ -41,4 +48,7 @@ off_time=1
 trigger=legato
 offset=20000
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/violas-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Violas Marcato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Violas Marcato.sfz
@@ -5,6 +5,11 @@
 // ------------------------------
 
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
+
 // -------
 // Sustain
 // -------
@@ -20,6 +25,9 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/violas-sustain.sfz"
 
 

--- a/Sonatina Symphonic Orchestra/Strings - Performance/Violas Sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/Violas Sustain.sfz
@@ -4,6 +4,10 @@
 //        Violas Sustain
 // ------------------------------
 
+<control>
+label_cc21=Vibrato
+set_cc21=0
+
 <group>
 ampeg_release=1.15
 amp_veltrack=0
@@ -15,4 +19,7 @@ cutoff_cc1=4800
 fil_keycenter=a3
 fil_keytrack=100
 
+#define $VIB_PITCH 20
+#define $VIB_DELAY 0
+#include "includes/vibrato.sfz"
 #include "includes/violas-sustain.sfz"

--- a/Sonatina Symphonic Orchestra/Strings - Performance/includes/vibrato.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/includes/vibrato.sfz
@@ -1,0 +1,23 @@
+// Use a LFO to modulate the pitch and volume based on CC 21.
+
+lfo01_pitch_oncc21=$VIB_PITCH
+lfo01_volume_oncc21=1
+lfo01_freq=5
+lfo01_freq_oncc21=2
+lfo01_delay=$VIB_DELAY
+lfo01_fade=0.5
+
+// Also vary the amount of high frequency harmonics.
+
+eq1_freq=2000
+eq1_bw=2
+lfo01_eq1gain_oncc21=3
+lfo01_eq1freq_oncc21=500
+
+// Using a complex waveform with multiple components gives a more natural sound.
+
+lfo01_wave=0
+lfo01_wave2=1
+lfo01_ratio2=0.48
+lfo01_offset2=0
+lfo01_scale2=0.2


### PR DESCRIPTION
Most of the strings have little or no vibrato.  The only exceptions are the solo violins and solo cello.  This PR allows you to algorithmically add it to the others.  CC 21 controls the strength of the vibrato.

The implementation is mostly based on https://sfzformat.com/tutorials/vibrato.  I had to do some things differently, because they rely on opcodes that aren't supported in sfizz.

All the ensemble sections default to not adding any vibrato.  Even if you turn it all the way up, the result is subtle.  It just adds a little character to the sound.

For the solo viola and bass the effect is much more pronounced.  They default to 50% vibrato. That's more idiomatic for how solo strings are typically played, and it produces a sound that's more consistent with the other solo strings.  Values much above 50% should only be used briefly, to add some extra expression to a line.