### PR TITLE
fix-filepath-capitalisation

### DIFF
--- a/Sonatina Symphonic Orchestra/Brass - Notation/Horn Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Notation/Horn Solo Staccato.sfz
@@ -47,7 +47,7 @@ fil_type=lpf_1p
 cutoff=500
 
 <region>
-sample=../Samples/horn/horn-e2.wav
+sample=../Samples/Horn/horn-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
@@ -55,7 +55,7 @@ tune=30
 offset=119315
 
 <region>
-sample=../Samples/horn/horn-g2.wav
+sample=../Samples/Horn/horn-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
@@ -64,42 +64,42 @@ volume=-1
 offset=126811
 
 <region>
-sample=../Samples/horn/horn-a#2.wav
+sample=../Samples/Horn/horn-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 offset=120509
 
 <region>
-sample=../Samples/horn/horn-c#3.wav
+sample=../Samples/Horn/horn-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 offset=115082
 
 <region>
-sample=../Samples/horn/horn-e3.wav
+sample=../Samples/Horn/horn-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 offset=97407
 
 <region>
-sample=../Samples/horn/horn-g3.wav
+sample=../Samples/Horn/horn-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 offset=146027
 
 <region>
-sample=../Samples/horn/horn-a#3.wav
+sample=../Samples/Horn/horn-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 offset=122643
 
 <region>
-sample=../Samples/horn/horn-c#4.wav
+sample=../Samples/Horn/horn-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -107,14 +107,14 @@ tune=-10
 offset=130085
 
 <region>
-sample=../Samples/horn/horn-e4.wav
+sample=../Samples/Horn/horn-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 offset=132865
 
 <region>
-sample=../Samples/horn/horn-g4.wav
+sample=../Samples/Horn/horn-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -122,7 +122,7 @@ tune=-8
 offset=108311
 
 <region>
-sample=../Samples/horn/horn-a#4.wav
+sample=../Samples/Horn/horn-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -130,7 +130,7 @@ tune=-9
 offset=117363
 
 <region>
-sample=../Samples/horn/horn-c#5.wav
+sample=../Samples/Horn/horn-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
@@ -138,7 +138,7 @@ tune=23
 offset=103318
 
 <region>
-sample=../Samples/horn/horn-e5.wav
+sample=../Samples/Horn/horn-e5.wav
 lokey=d#5
 hikey=e5
 pitch_keycenter=e5

--- a/Sonatina Symphonic Orchestra/Brass - Notation/Tenor Trombone Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Notation/Tenor Trombone Solo Staccato.sfz
@@ -47,77 +47,77 @@ fil_type=lpf_1p
 cutoff=500
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
 offset=79963
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 offset=91608
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 offset=88643
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 offset=88794
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 offset=91634
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 offset=86105
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 offset=89346
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 offset=84819
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 offset=93261
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 offset=92369
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4

--- a/Sonatina Symphonic Orchestra/Brass - Notation/Trumpet Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Notation/Trumpet Solo Staccato.sfz
@@ -47,7 +47,7 @@ fil_type=lpf_1p
 cutoff=400
 
 <region>
-sample=../Samples/trumpet/trumpet-e3.wav
+sample=../Samples/Trumpet/trumpet-e3.wav
 lokey=e3
 hikey=f3
 pitch_keycenter=e3
@@ -55,7 +55,7 @@ tune=-6
 offset=178959
 
 <region>
-sample=../Samples/trumpet/trumpet-g3.wav
+sample=../Samples/Trumpet/trumpet-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -63,7 +63,7 @@ tune=8
 offset=189442
 
 <region>
-sample=../Samples/trumpet/trumpet-a#3.wav
+sample=../Samples/Trumpet/trumpet-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -72,21 +72,21 @@ volume=-1
 offset=192670
 
 <region>
-sample=../Samples/trumpet/trumpet-c#4.wav
+sample=../Samples/Trumpet/trumpet-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 offset=176689
 
 <region>
-sample=../Samples/trumpet/trumpet-e4.wav
+sample=../Samples/Trumpet/trumpet-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 offset=186129
 
 <region>
-sample=../Samples/trumpet/trumpet-g4.wav
+sample=../Samples/Trumpet/trumpet-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -94,7 +94,7 @@ tune=-8
 offset=183771
 
 <region>
-sample=../Samples/trumpet/trumpet-a#4.wav
+sample=../Samples/Trumpet/trumpet-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -103,14 +103,14 @@ volume=-1
 offset=181692
 
 <region>
-sample=../Samples/trumpet/trumpet-c#5.wav
+sample=../Samples/Trumpet/trumpet-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 offset=181641
 
 <region>
-sample=../Samples/trumpet/trumpet-e5.wav
+sample=../Samples/Trumpet/trumpet-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
@@ -118,7 +118,7 @@ tune=-10
 offset=193174
 
 <region>
-sample=../Samples/trumpet/trumpet-g5.wav
+sample=../Samples/Trumpet/trumpet-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -126,14 +126,14 @@ tune=-4
 offset=195568
 
 <region>
-sample=../Samples/trumpet/trumpet-a#5.wav
+sample=../Samples/Trumpet/trumpet-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 offset=187000
 
 <region>
-sample=../Samples/trumpet/trumpet-c#6.wav
+sample=../Samples/Trumpet/trumpet-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -142,7 +142,7 @@ volume=1
 offset=196674
 
 <region>
-sample=../Samples/trumpet/trumpet-e6.wav
+sample=../Samples/Trumpet/trumpet-e6.wav
 lokey=d#6
 hikey=e6
 pitch_keycenter=e6

--- a/Sonatina Symphonic Orchestra/Brass - Notation/includes/horn-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Notation/includes/horn-solo.sfz
@@ -1,12 +1,12 @@
 <region>
-sample=../Samples/horn/horn-e2.wav
+sample=../Samples/Horn/horn-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
 tune=30
 
 <region>
-sample=../Samples/horn/horn-g2.wav
+sample=../Samples/Horn/horn-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
@@ -14,72 +14,72 @@ tune=-11
 volume=-1
 
 <region>
-sample=../Samples/horn/horn-a#2.wav
+sample=../Samples/Horn/horn-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/horn/horn-c#3.wav
+sample=../Samples/Horn/horn-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 
 <region>
-sample=../Samples/horn/horn-e3.wav
+sample=../Samples/Horn/horn-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 
 <region>
-sample=../Samples/horn/horn-g3.wav
+sample=../Samples/Horn/horn-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/horn/horn-a#3.wav
+sample=../Samples/Horn/horn-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 
 <region>
-sample=../Samples/horn/horn-c#4.wav
+sample=../Samples/Horn/horn-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=-10
 
 <region>
-sample=../Samples/horn/horn-e4.wav
+sample=../Samples/Horn/horn-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 volume=-2
 
 <region>
-sample=../Samples/horn/horn-g4.wav
+sample=../Samples/Horn/horn-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-8
 
 <region>
-sample=../Samples/horn/horn-a#4.wav
+sample=../Samples/Horn/horn-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 tune=-9
 
 <region>
-sample=../Samples/horn/horn-c#5.wav
+sample=../Samples/Horn/horn-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 tune=23
 
 <region>
-sample=../Samples/horn/horn-e5.wav
+sample=../Samples/Horn/horn-e5.wav
 lokey=d#5
 hikey=e5
 pitch_keycenter=e5

--- a/Sonatina Symphonic Orchestra/Brass - Notation/includes/tenor-trombone-solo-offset-attacks.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Notation/includes/tenor-trombone-solo-offset-attacks.sfz
@@ -1,32 +1,32 @@
 // This version of the file corrects for bad attacks.
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 volume=-2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
@@ -35,37 +35,37 @@ ampeg_attack=0.4
 volume=-1
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4

--- a/Sonatina Symphonic Orchestra/Brass - Notation/includes/tenor-trombone-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Notation/includes/tenor-trombone-solo.sfz
@@ -1,67 +1,67 @@
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 volume=-2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 volume=-1
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4

--- a/Sonatina Symphonic Orchestra/Brass - Notation/includes/trumpet-solo-offset-attacks.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Notation/includes/trumpet-solo-offset-attacks.sfz
@@ -1,7 +1,7 @@
 // This version of the file corrects for bad attacks.
 
 <region>
-sample=../Samples/trumpet/trumpet-e3.wav
+sample=../Samples/Trumpet/trumpet-e3.wav
 lokey=e3
 hikey=f3
 pitch_keycenter=e3
@@ -10,7 +10,7 @@ offset=9000
 ampeg_attack=0.04
 
 <region>
-sample=../Samples/trumpet/trumpet-g3.wav
+sample=../Samples/Trumpet/trumpet-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -19,7 +19,7 @@ offset=2000
 ampeg_attack=0.04
 
 <region>
-sample=../Samples/trumpet/trumpet-a#3.wav
+sample=../Samples/Trumpet/trumpet-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -29,26 +29,26 @@ offset=5000
 ampeg_attack=0.04
 
 <region>
-sample=../Samples/trumpet/trumpet-c#4.wav
+sample=../Samples/Trumpet/trumpet-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 
 <region>
-sample=../Samples/trumpet/trumpet-e4.wav
+sample=../Samples/Trumpet/trumpet-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/trumpet/trumpet-g4.wav
+sample=../Samples/Trumpet/trumpet-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-8
 
 <region>
-sample=../Samples/trumpet/trumpet-a#4.wav
+sample=../Samples/Trumpet/trumpet-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -56,20 +56,20 @@ tune=-4
 volume=-1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#5.wav
+sample=../Samples/Trumpet/trumpet-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 
 <region>
-sample=../Samples/trumpet/trumpet-e5.wav
+sample=../Samples/Trumpet/trumpet-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
 tune=-10
 
 <region>
-sample=../Samples/trumpet/trumpet-g5.wav
+sample=../Samples/Trumpet/trumpet-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -77,14 +77,14 @@ tune=-4
 volume=-3
 
 <region>
-sample=../Samples/trumpet/trumpet-a#5.wav
+sample=../Samples/Trumpet/trumpet-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 volume=1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#6.wav
+sample=../Samples/Trumpet/trumpet-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -94,7 +94,7 @@ offset=3000
 ampeg_attack=0.04
 
 <region>
-sample=../Samples/trumpet/trumpet-e6.wav
+sample=../Samples/Trumpet/trumpet-e6.wav
 lokey=d#6
 hikey=e6
 pitch_keycenter=e6

--- a/Sonatina Symphonic Orchestra/Brass - Notation/includes/trumpet-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Notation/includes/trumpet-solo.sfz
@@ -1,19 +1,19 @@
 <region>
-sample=../Samples/trumpet/trumpet-e3.wav
+sample=../Samples/Trumpet/trumpet-e3.wav
 lokey=e3
 hikey=f3
 pitch_keycenter=e3
 tune=-6
 
 <region>
-sample=../Samples/trumpet/trumpet-g3.wav
+sample=../Samples/Trumpet/trumpet-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 tune=8
 
 <region>
-sample=../Samples/trumpet/trumpet-a#3.wav
+sample=../Samples/Trumpet/trumpet-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -21,26 +21,26 @@ tune=12
 volume=-1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#4.wav
+sample=../Samples/Trumpet/trumpet-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 
 <region>
-sample=../Samples/trumpet/trumpet-e4.wav
+sample=../Samples/Trumpet/trumpet-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/trumpet/trumpet-g4.wav
+sample=../Samples/Trumpet/trumpet-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-8
 
 <region>
-sample=../Samples/trumpet/trumpet-a#4.wav
+sample=../Samples/Trumpet/trumpet-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -48,20 +48,20 @@ tune=-4
 volume=-1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#5.wav
+sample=../Samples/Trumpet/trumpet-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 
 <region>
-sample=../Samples/trumpet/trumpet-e5.wav
+sample=../Samples/Trumpet/trumpet-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
 tune=-10
 
 <region>
-sample=../Samples/trumpet/trumpet-g5.wav
+sample=../Samples/Trumpet/trumpet-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -69,14 +69,14 @@ tune=-4
 volume=-3
 
 <region>
-sample=../Samples/trumpet/trumpet-a#5.wav
+sample=../Samples/Trumpet/trumpet-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 volume=1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#6.wav
+sample=../Samples/Trumpet/trumpet-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -84,7 +84,7 @@ tune=5
 volume=2
 
 <region>
-sample=../Samples/trumpet/trumpet-e6.wav
+sample=../Samples/Trumpet/trumpet-e6.wav
 lokey=d#6
 hikey=e6
 pitch_keycenter=e6

--- a/Sonatina Symphonic Orchestra/Brass - Performance/Horn Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Performance/Horn Solo Staccato.sfz
@@ -47,7 +47,7 @@ fil_type=lpf_1p
 cutoff=500
 
 <region>
-sample=../Samples/horn/horn-e2.wav
+sample=../Samples/Horn/horn-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
@@ -55,7 +55,7 @@ tune=30
 offset=119315
 
 <region>
-sample=../Samples/horn/horn-g2.wav
+sample=../Samples/Horn/horn-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
@@ -64,42 +64,42 @@ volume=-1
 offset=126811
 
 <region>
-sample=../Samples/horn/horn-a#2.wav
+sample=../Samples/Horn/horn-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 offset=120509
 
 <region>
-sample=../Samples/horn/horn-c#3.wav
+sample=../Samples/Horn/horn-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 offset=115082
 
 <region>
-sample=../Samples/horn/horn-e3.wav
+sample=../Samples/Horn/horn-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 offset=97407
 
 <region>
-sample=../Samples/horn/horn-g3.wav
+sample=../Samples/Horn/horn-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 offset=146027
 
 <region>
-sample=../Samples/horn/horn-a#3.wav
+sample=../Samples/Horn/horn-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 offset=122643
 
 <region>
-sample=../Samples/horn/horn-c#4.wav
+sample=../Samples/Horn/horn-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -107,14 +107,14 @@ tune=-10
 offset=130085
 
 <region>
-sample=../Samples/horn/horn-e4.wav
+sample=../Samples/Horn/horn-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 offset=132865
 
 <region>
-sample=../Samples/horn/horn-g4.wav
+sample=../Samples/Horn/horn-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -122,7 +122,7 @@ tune=-8
 offset=108311
 
 <region>
-sample=../Samples/horn/horn-a#4.wav
+sample=../Samples/Horn/horn-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -130,7 +130,7 @@ tune=-9
 offset=117363
 
 <region>
-sample=../Samples/horn/horn-c#5.wav
+sample=../Samples/Horn/horn-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
@@ -138,7 +138,7 @@ tune=23
 offset=103318
 
 <region>
-sample=../Samples/horn/horn-e5.wav
+sample=../Samples/Horn/horn-e5.wav
 lokey=d#5
 hikey=e5
 pitch_keycenter=e5

--- a/Sonatina Symphonic Orchestra/Brass - Performance/Tenor Trombone Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Performance/Tenor Trombone Solo Staccato.sfz
@@ -47,77 +47,77 @@ fil_type=lpf_1p
 cutoff=500
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
 offset=79963
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 offset=91608
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 offset=88643
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 offset=88794
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 offset=91634
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 offset=86105
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 offset=89346
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 offset=84819
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 offset=93261
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 offset=92369
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4

--- a/Sonatina Symphonic Orchestra/Brass - Performance/Trumpet Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Performance/Trumpet Solo Staccato.sfz
@@ -47,7 +47,7 @@ fil_type=lpf_1p
 cutoff=400
 
 <region>
-sample=../Samples/trumpet/trumpet-e3.wav
+sample=../Samples/Trumpet/trumpet-e3.wav
 lokey=e3
 hikey=f3
 pitch_keycenter=e3
@@ -55,7 +55,7 @@ tune=-6
 offset=178959
 
 <region>
-sample=../Samples/trumpet/trumpet-g3.wav
+sample=../Samples/Trumpet/trumpet-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -63,7 +63,7 @@ tune=8
 offset=189442
 
 <region>
-sample=../Samples/trumpet/trumpet-a#3.wav
+sample=../Samples/Trumpet/trumpet-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -72,21 +72,21 @@ volume=-1
 offset=192670
 
 <region>
-sample=../Samples/trumpet/trumpet-c#4.wav
+sample=../Samples/Trumpet/trumpet-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 offset=176689
 
 <region>
-sample=../Samples/trumpet/trumpet-e4.wav
+sample=../Samples/Trumpet/trumpet-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 offset=186129
 
 <region>
-sample=../Samples/trumpet/trumpet-g4.wav
+sample=../Samples/Trumpet/trumpet-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -94,7 +94,7 @@ tune=-8
 offset=183771
 
 <region>
-sample=../Samples/trumpet/trumpet-a#4.wav
+sample=../Samples/Trumpet/trumpet-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -103,14 +103,14 @@ volume=-1
 offset=181692
 
 <region>
-sample=../Samples/trumpet/trumpet-c#5.wav
+sample=../Samples/Trumpet/trumpet-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 offset=181641
 
 <region>
-sample=../Samples/trumpet/trumpet-e5.wav
+sample=../Samples/Trumpet/trumpet-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
@@ -118,7 +118,7 @@ tune=-10
 offset=193174
 
 <region>
-sample=../Samples/trumpet/trumpet-g5.wav
+sample=../Samples/Trumpet/trumpet-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -126,14 +126,14 @@ tune=-4
 offset=195568
 
 <region>
-sample=../Samples/trumpet/trumpet-a#5.wav
+sample=../Samples/Trumpet/trumpet-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 offset=187000
 
 <region>
-sample=../Samples/trumpet/trumpet-c#6.wav
+sample=../Samples/Trumpet/trumpet-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -142,7 +142,7 @@ volume=1
 offset=196674
 
 <region>
-sample=../Samples/trumpet/trumpet-e6.wav
+sample=../Samples/Trumpet/trumpet-e6.wav
 lokey=d#6
 hikey=e6
 pitch_keycenter=e6

--- a/Sonatina Symphonic Orchestra/Brass - Performance/includes/horn-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Performance/includes/horn-solo.sfz
@@ -1,12 +1,12 @@
 <region>
-sample=../Samples/horn/horn-e2.wav
+sample=../Samples/Horn/horn-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
 tune=30
 
 <region>
-sample=../Samples/horn/horn-g2.wav
+sample=../Samples/Horn/horn-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
@@ -14,72 +14,72 @@ tune=-11
 volume=-1
 
 <region>
-sample=../Samples/horn/horn-a#2.wav
+sample=../Samples/Horn/horn-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/horn/horn-c#3.wav
+sample=../Samples/Horn/horn-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 
 <region>
-sample=../Samples/horn/horn-e3.wav
+sample=../Samples/Horn/horn-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 
 <region>
-sample=../Samples/horn/horn-g3.wav
+sample=../Samples/Horn/horn-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/horn/horn-a#3.wav
+sample=../Samples/Horn/horn-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 
 <region>
-sample=../Samples/horn/horn-c#4.wav
+sample=../Samples/Horn/horn-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=-10
 
 <region>
-sample=../Samples/horn/horn-e4.wav
+sample=../Samples/Horn/horn-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 volume=-2
 
 <region>
-sample=../Samples/horn/horn-g4.wav
+sample=../Samples/Horn/horn-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-8
 
 <region>
-sample=../Samples/horn/horn-a#4.wav
+sample=../Samples/Horn/horn-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 tune=-9
 
 <region>
-sample=../Samples/horn/horn-c#5.wav
+sample=../Samples/Horn/horn-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 tune=23
 
 <region>
-sample=../Samples/horn/horn-e5.wav
+sample=../Samples/Horn/horn-e5.wav
 lokey=d#5
 hikey=e5
 pitch_keycenter=e5

--- a/Sonatina Symphonic Orchestra/Brass - Performance/includes/tenor-trombone-solo-offset-attacks.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Performance/includes/tenor-trombone-solo-offset-attacks.sfz
@@ -1,32 +1,32 @@
 // This version of the file corrects for bad attacks.
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 volume=-2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
@@ -35,37 +35,37 @@ ampeg_attack=0.4
 volume=-1
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4

--- a/Sonatina Symphonic Orchestra/Brass - Performance/includes/tenor-trombone-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Performance/includes/tenor-trombone-solo.sfz
@@ -1,67 +1,67 @@
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e2.wav
 lokey=e2
 hikey=f2
 pitch_keycenter=e2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 volume=-2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#2.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 volume=-1
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#3.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-c#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-e4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-g4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 
 <region>
-sample=../Samples/tenor trombone/tenor_trombone-a#4.wav
+sample=../Samples/Tenor trombone/tenor_trombone-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4

--- a/Sonatina Symphonic Orchestra/Brass - Performance/includes/trumpet-solo-offset-attacks.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Performance/includes/trumpet-solo-offset-attacks.sfz
@@ -1,7 +1,7 @@
 // This version of the file corrects for bad attacks.
 
 <region>
-sample=../Samples/trumpet/trumpet-e3.wav
+sample=../Samples/Trumpet/trumpet-e3.wav
 lokey=e3
 hikey=f3
 pitch_keycenter=e3
@@ -10,7 +10,7 @@ offset=9000
 ampeg_attack=0.04
 
 <region>
-sample=../Samples/trumpet/trumpet-g3.wav
+sample=../Samples/Trumpet/trumpet-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -19,7 +19,7 @@ offset=2000
 ampeg_attack=0.04
 
 <region>
-sample=../Samples/trumpet/trumpet-a#3.wav
+sample=../Samples/Trumpet/trumpet-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -29,26 +29,26 @@ offset=5000
 ampeg_attack=0.04
 
 <region>
-sample=../Samples/trumpet/trumpet-c#4.wav
+sample=../Samples/Trumpet/trumpet-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 
 <region>
-sample=../Samples/trumpet/trumpet-e4.wav
+sample=../Samples/Trumpet/trumpet-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/trumpet/trumpet-g4.wav
+sample=../Samples/Trumpet/trumpet-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-8
 
 <region>
-sample=../Samples/trumpet/trumpet-a#4.wav
+sample=../Samples/Trumpet/trumpet-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -56,20 +56,20 @@ tune=-4
 volume=-1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#5.wav
+sample=../Samples/Trumpet/trumpet-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 
 <region>
-sample=../Samples/trumpet/trumpet-e5.wav
+sample=../Samples/Trumpet/trumpet-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
 tune=-10
 
 <region>
-sample=../Samples/trumpet/trumpet-g5.wav
+sample=../Samples/Trumpet/trumpet-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -77,14 +77,14 @@ tune=-4
 volume=-3
 
 <region>
-sample=../Samples/trumpet/trumpet-a#5.wav
+sample=../Samples/Trumpet/trumpet-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 volume=1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#6.wav
+sample=../Samples/Trumpet/trumpet-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -94,7 +94,7 @@ offset=3000
 ampeg_attack=0.04
 
 <region>
-sample=../Samples/trumpet/trumpet-e6.wav
+sample=../Samples/Trumpet/trumpet-e6.wav
 lokey=d#6
 hikey=e6
 pitch_keycenter=e6

--- a/Sonatina Symphonic Orchestra/Brass - Performance/includes/trumpet-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Brass - Performance/includes/trumpet-solo.sfz
@@ -1,19 +1,19 @@
 <region>
-sample=../Samples/trumpet/trumpet-e3.wav
+sample=../Samples/Trumpet/trumpet-e3.wav
 lokey=e3
 hikey=f3
 pitch_keycenter=e3
 tune=-6
 
 <region>
-sample=../Samples/trumpet/trumpet-g3.wav
+sample=../Samples/Trumpet/trumpet-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 tune=8
 
 <region>
-sample=../Samples/trumpet/trumpet-a#3.wav
+sample=../Samples/Trumpet/trumpet-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -21,26 +21,26 @@ tune=12
 volume=-1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#4.wav
+sample=../Samples/Trumpet/trumpet-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 
 <region>
-sample=../Samples/trumpet/trumpet-e4.wav
+sample=../Samples/Trumpet/trumpet-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/trumpet/trumpet-g4.wav
+sample=../Samples/Trumpet/trumpet-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-8
 
 <region>
-sample=../Samples/trumpet/trumpet-a#4.wav
+sample=../Samples/Trumpet/trumpet-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -48,20 +48,20 @@ tune=-4
 volume=-1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#5.wav
+sample=../Samples/Trumpet/trumpet-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 
 <region>
-sample=../Samples/trumpet/trumpet-e5.wav
+sample=../Samples/Trumpet/trumpet-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
 tune=-10
 
 <region>
-sample=../Samples/trumpet/trumpet-g5.wav
+sample=../Samples/Trumpet/trumpet-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -69,14 +69,14 @@ tune=-4
 volume=-3
 
 <region>
-sample=../Samples/trumpet/trumpet-a#5.wav
+sample=../Samples/Trumpet/trumpet-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 volume=1
 
 <region>
-sample=../Samples/trumpet/trumpet-c#6.wav
+sample=../Samples/Trumpet/trumpet-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -84,7 +84,7 @@ tune=5
 volume=2
 
 <region>
-sample=../Samples/trumpet/trumpet-e6.wav
+sample=../Samples/Trumpet/trumpet-e6.wav
 lokey=d#6
 hikey=e6
 pitch_keycenter=e6

--- a/Sonatina Symphonic Orchestra/Strings - Notation/includes/cello-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/includes/cello-solo.sfz
@@ -1,5 +1,5 @@
 <region>
-sample=../Samples/cello/cello-c2.wav
+sample=../Samples/Cello/cello-c2.wav
 lokey=c2
 hikey=c#2
 pitch_keycenter=c2
@@ -7,7 +7,7 @@ tune=-1
 volume=-2
 
 <region>
-sample=../Samples/cello/cello-d#2.wav
+sample=../Samples/Cello/cello-d#2.wav
 lokey=d2
 hikey=e2
 pitch_keycenter=d#2
@@ -15,7 +15,7 @@ tune=-6
 volume=-3
 
 <region>
-sample=../Samples/cello/cello-f#2.wav
+sample=../Samples/Cello/cello-f#2.wav
 lokey=f2
 hikey=g2
 pitch_keycenter=f#2
@@ -23,14 +23,14 @@ tune=-5
 volume=1
 
 <region>
-sample=../Samples/cello/cello-a2.wav
+sample=../Samples/Cello/cello-a2.wav
 lokey=g#2
 hikey=a#2
 pitch_keycenter=a2
 volume=1
 
 <region>
-sample=../Samples/cello/cello-c3.wav
+sample=../Samples/Cello/cello-c3.wav
 lokey=b2
 hikey=c#3
 pitch_keycenter=c3
@@ -38,21 +38,21 @@ tune=7
 volume=2
 
 <region>
-sample=../Samples/cello/cello-d#3.wav
+sample=../Samples/Cello/cello-d#3.wav
 lokey=d3
 hikey=e3
 pitch_keycenter=d#3
 tune=13
 
 <region>
-sample=../Samples/cello/cello-f#3.wav
+sample=../Samples/Cello/cello-f#3.wav
 lokey=f3
 hikey=g3
 pitch_keycenter=f#3
 tune=-3
 
 <region>
-sample=../Samples/cello/cello-a3.wav
+sample=../Samples/Cello/cello-a3.wav
 lokey=g#3
 hikey=a#3
 pitch_keycenter=a3
@@ -60,7 +60,7 @@ tune=-6
 volume=-3
 
 <region>
-sample=../Samples/cello/cello-c4.wav
+sample=../Samples/Cello/cello-c4.wav
 lokey=b3
 hikey=c#4
 pitch_keycenter=c4
@@ -68,7 +68,7 @@ tune=-2
 volume=-2
 
 <region>
-sample=../Samples/cello/cello-d#4.wav
+sample=../Samples/Cello/cello-d#4.wav
 lokey=d4
 hikey=e4
 pitch_keycenter=d#4
@@ -76,7 +76,7 @@ tune=-16
 volume=3
 
 <region>
-sample=../Samples/cello/cello-f#4.wav
+sample=../Samples/Cello/cello-f#4.wav
 lokey=f4
 hikey=g4
 pitch_keycenter=f#4
@@ -84,7 +84,7 @@ tune=-24
 volume=-1
 
 <region>
-sample=../Samples/cello/cello-a4.flac
+sample=../Samples/Cello/cello-a4.flac
 lokey=g#4
 hikey=a#4
 pitch_keycenter=a4
@@ -92,14 +92,14 @@ tune=-4
 volume=-4
 
 <region>
-sample=../Samples/cello/cello-c5.flac
+sample=../Samples/Cello/cello-c5.flac
 lokey=b4
 hikey=c#5
 pitch_keycenter=c5
 tune=-8
 
 <region>
-sample=../Samples/cello/cello-d#5.wav
+sample=../Samples/Cello/cello-d#5.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
@@ -107,14 +107,14 @@ tune=-4
 volume=-2
 
 <region>
-sample=../Samples/cello/cello-f#5.flac
+sample=../Samples/Cello/cello-f#5.flac
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
 tune=-18
 
 <region>
-sample=../Samples/cello/cello-a5.flac
+sample=../Samples/Cello/cello-a5.flac
 lokey=g#5
 hikey=c6
 pitch_keycenter=a5

--- a/Sonatina Symphonic Orchestra/Strings - Notation/includes/violin-solo-1-sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Notation/includes/violin-solo-1-sustain.sfz
@@ -1,71 +1,71 @@
 <region>
-sample=../Samples/violin/violin-g3.wav
+sample=../Samples/Violin/violin-g3.wav
 lokey=g3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/violin/violin-a#3.wav
+sample=../Samples/Violin/violin-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 tune=8
 
 <region>
-sample=../Samples/violin/violin-c#4.wav
+sample=../Samples/Violin/violin-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=-2
 
 <region>
-sample=../Samples/violin/violin-e4.wav
+sample=../Samples/Violin/violin-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 tune=6
 
 <region>
-sample=../Samples/violin/violin-g4.wav
+sample=../Samples/Violin/violin-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 
 <region>
-sample=../Samples/violin/violin-a#4.flac
+sample=../Samples/Violin/violin-a#4.flac
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 
 <region>
-sample=../Samples/violin/violin-c#5.wav
+sample=../Samples/Violin/violin-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 
 <region>
-sample=../Samples/violin/violin-e5.wav
+sample=../Samples/Violin/violin-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
 tune=3
 
 <region>
-sample=../Samples/violin/violin-g5.wav
+sample=../Samples/Violin/violin-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
 tune=-2
 
 <region>
-sample=../Samples/violin/violin-a#5.wav
+sample=../Samples/Violin/violin-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 tune=-8
 
 <region>
-sample=../Samples/violin/violin-c#6.wav
+sample=../Samples/Violin/violin-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -73,21 +73,21 @@ tune=-8
 volume=1
 
 <region>
-sample=../Samples/violin/violin-e6.wav
+sample=../Samples/Violin/violin-e6.wav
 lokey=d#6
 hikey=f6
 pitch_keycenter=e6
 tune=-9
 
 <region>
-sample=../Samples/violin/violin-g6.wav
+sample=../Samples/Violin/violin-g6.wav
 lokey=f#6
 hikey=g#6
 pitch_keycenter=g6
 tune=-40
 
 <region>
-sample=../Samples/violin/violin-a#6.wav
+sample=../Samples/Violin/violin-a#6.wav
 lokey=a6
 hikey=c7
 pitch_keycenter=a#6

--- a/Sonatina Symphonic Orchestra/Strings - Performance/includes/cello-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/includes/cello-solo.sfz
@@ -1,5 +1,5 @@
 <region>
-sample=../Samples/cello/cello-c2.wav
+sample=../Samples/Cello/cello-c2.wav
 lokey=c2
 hikey=c#2
 pitch_keycenter=c2
@@ -7,7 +7,7 @@ tune=-1
 volume=-2
 
 <region>
-sample=../Samples/cello/cello-d#2.wav
+sample=../Samples/Cello/cello-d#2.wav
 lokey=d2
 hikey=e2
 pitch_keycenter=d#2
@@ -15,7 +15,7 @@ tune=-6
 volume=-3
 
 <region>
-sample=../Samples/cello/cello-f#2.wav
+sample=../Samples/Cello/cello-f#2.wav
 lokey=f2
 hikey=g2
 pitch_keycenter=f#2
@@ -23,14 +23,14 @@ tune=-5
 volume=1
 
 <region>
-sample=../Samples/cello/cello-a2.wav
+sample=../Samples/Cello/cello-a2.wav
 lokey=g#2
 hikey=a#2
 pitch_keycenter=a2
 volume=1
 
 <region>
-sample=../Samples/cello/cello-c3.wav
+sample=../Samples/Cello/cello-c3.wav
 lokey=b2
 hikey=c#3
 pitch_keycenter=c3
@@ -38,21 +38,21 @@ tune=7
 volume=2
 
 <region>
-sample=../Samples/cello/cello-d#3.wav
+sample=../Samples/Cello/cello-d#3.wav
 lokey=d3
 hikey=e3
 pitch_keycenter=d#3
 tune=13
 
 <region>
-sample=../Samples/cello/cello-f#3.wav
+sample=../Samples/Cello/cello-f#3.wav
 lokey=f3
 hikey=g3
 pitch_keycenter=f#3
 tune=-3
 
 <region>
-sample=../Samples/cello/cello-a3.wav
+sample=../Samples/Cello/cello-a3.wav
 lokey=g#3
 hikey=a#3
 pitch_keycenter=a3
@@ -60,7 +60,7 @@ tune=-6
 volume=-3
 
 <region>
-sample=../Samples/cello/cello-c4.wav
+sample=../Samples/Cello/cello-c4.wav
 lokey=b3
 hikey=c#4
 pitch_keycenter=c4
@@ -68,7 +68,7 @@ tune=-2
 volume=-2
 
 <region>
-sample=../Samples/cello/cello-d#4.wav
+sample=../Samples/Cello/cello-d#4.wav
 lokey=d4
 hikey=e4
 pitch_keycenter=d#4
@@ -76,7 +76,7 @@ tune=-16
 volume=3
 
 <region>
-sample=../Samples/cello/cello-f#4.wav
+sample=../Samples/Cello/cello-f#4.wav
 lokey=f4
 hikey=g4
 pitch_keycenter=f#4
@@ -84,7 +84,7 @@ tune=-24
 volume=-1
 
 <region>
-sample=../Samples/cello/cello-a4.flac
+sample=../Samples/Cello/cello-a4.flac
 lokey=g#4
 hikey=a#4
 pitch_keycenter=a4
@@ -92,14 +92,14 @@ tune=-4
 volume=-4
 
 <region>
-sample=../Samples/cello/cello-c5.flac
+sample=../Samples/Cello/cello-c5.flac
 lokey=b4
 hikey=c#5
 pitch_keycenter=c5
 tune=-8
 
 <region>
-sample=../Samples/cello/cello-d#5.wav
+sample=../Samples/Cello/cello-d#5.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
@@ -107,14 +107,14 @@ tune=-4
 volume=-2
 
 <region>
-sample=../Samples/cello/cello-f#5.flac
+sample=../Samples/Cello/cello-f#5.flac
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
 tune=-18
 
 <region>
-sample=../Samples/cello/cello-a5.flac
+sample=../Samples/Cello/cello-a5.flac
 lokey=g#5
 hikey=c6
 pitch_keycenter=a5

--- a/Sonatina Symphonic Orchestra/Strings - Performance/includes/violin-solo-1-sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Strings - Performance/includes/violin-solo-1-sustain.sfz
@@ -1,71 +1,71 @@
 <region>
-sample=../Samples/violin/violin-g3.wav
+sample=../Samples/Violin/violin-g3.wav
 lokey=g3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/violin/violin-a#3.wav
+sample=../Samples/Violin/violin-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 tune=8
 
 <region>
-sample=../Samples/violin/violin-c#4.wav
+sample=../Samples/Violin/violin-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=-2
 
 <region>
-sample=../Samples/violin/violin-e4.wav
+sample=../Samples/Violin/violin-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 tune=6
 
 <region>
-sample=../Samples/violin/violin-g4.wav
+sample=../Samples/Violin/violin-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 
 <region>
-sample=../Samples/violin/violin-a#4.flac
+sample=../Samples/Violin/violin-a#4.flac
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 
 <region>
-sample=../Samples/violin/violin-c#5.wav
+sample=../Samples/Violin/violin-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 
 <region>
-sample=../Samples/violin/violin-e5.wav
+sample=../Samples/Violin/violin-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
 tune=3
 
 <region>
-sample=../Samples/violin/violin-g5.wav
+sample=../Samples/Violin/violin-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
 tune=-2
 
 <region>
-sample=../Samples/violin/violin-a#5.wav
+sample=../Samples/Violin/violin-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 tune=-8
 
 <region>
-sample=../Samples/violin/violin-c#6.wav
+sample=../Samples/Violin/violin-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -73,21 +73,21 @@ tune=-8
 volume=1
 
 <region>
-sample=../Samples/violin/violin-e6.wav
+sample=../Samples/Violin/violin-e6.wav
 lokey=d#6
 hikey=f6
 pitch_keycenter=e6
 tune=-9
 
 <region>
-sample=../Samples/violin/violin-g6.wav
+sample=../Samples/Violin/violin-g6.wav
 lokey=f#6
 hikey=g#6
 pitch_keycenter=g6
 tune=-40
 
 <region>
-sample=../Samples/violin/violin-a#6.wav
+sample=../Samples/Violin/violin-a#6.wav
 lokey=a6
 hikey=c7
 pitch_keycenter=a#6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/Bass Clarinet Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/Bass Clarinet Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d2.wav
 lokey=d2
 hikey=d#2
 pitch_keycenter=d2
@@ -49,7 +49,7 @@ tune=25
 offset=90000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f2.wav
 lokey=e2
 hikey=f#2
 pitch_keycenter=f2
@@ -57,14 +57,14 @@ tune=6
 offset=94000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#2.wav
 lokey=g2
 hikey=a2
 pitch_keycenter=g#2
 offset=88000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b2.wav
 lokey=a#2
 hikey=c3
 pitch_keycenter=b2
@@ -72,7 +72,7 @@ tune=10
 offset=91000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d3.wav
 lokey=c#3
 hikey=d#3
 pitch_keycenter=d3
@@ -80,7 +80,7 @@ tune=5
 offset=94000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
@@ -88,7 +88,7 @@ tune=8
 offset=88000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
@@ -96,7 +96,7 @@ tune=23
 offset=85000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
@@ -104,7 +104,7 @@ tune=7
 offset=88000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
@@ -112,7 +112,7 @@ tune=4
 offset=94000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
@@ -120,7 +120,7 @@ tune=15
 offset=84000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
@@ -128,7 +128,7 @@ ampeg_attack=0.1
 offset=91000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
@@ -136,7 +136,7 @@ tune=3
 offset=87000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d5.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d5.wav
 lokey=c#5
 hikey=d5
 pitch_keycenter=d5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/Bassoon Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/Bassoon Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/bassoon/bassoon-a#1.wav
+sample=../Samples/Bassoon/bassoon-a#1.wav
 lokey=a#1
 hikey=b1
 pitch_keycenter=a#1
@@ -49,7 +49,7 @@ tune=-13
 offset=85000
 
 <region>
-sample=../Samples/bassoon/bassoon-c#2.wav
+sample=../Samples/Bassoon/bassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
@@ -57,7 +57,7 @@ tune=-17
 offset=90000
 
 <region>
-sample=../Samples/bassoon/bassoon-e2.wav
+sample=../Samples/Bassoon/bassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
@@ -65,21 +65,21 @@ tune=-12
 offset=95000
 
 <region>
-sample=../Samples/bassoon/bassoon-g2.wav
+sample=../Samples/Bassoon/bassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 offset=95000
 
 <region>
-sample=../Samples/bassoon/bassoon-a#2.wav
+sample=../Samples/Bassoon/bassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 offset=96000
 
 <region>
-sample=../Samples/bassoon/bassoon-c#3.wav
+sample=../Samples/Bassoon/bassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
@@ -87,7 +87,7 @@ tune=-12
 offset=85000
 
 <region>
-sample=../Samples/bassoon/bassoon-e3.wav
+sample=../Samples/Bassoon/bassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
@@ -95,7 +95,7 @@ tune=-11
 offset=97000
 
 <region>
-sample=../Samples/bassoon/bassoon-g3.wav
+sample=../Samples/Bassoon/bassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -103,7 +103,7 @@ tune=-5
 offset=91000
 
 <region>
-sample=../Samples/bassoon/bassoon-a#3.wav
+sample=../Samples/Bassoon/bassoon-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -111,7 +111,7 @@ tune=-4
 offset=88500
 
 <region>
-sample=../Samples/bassoon/bassoon-c#4.wav
+sample=../Samples/Bassoon/bassoon-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -119,14 +119,14 @@ tune=5
 offset=112000
 
 <region>
-sample=../Samples/bassoon/bassoon-e4.wav
+sample=../Samples/Bassoon/bassoon-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 offset=101000
 
 <region>
-sample=../Samples/bassoon/bassoon-g4.wav
+sample=../Samples/Bassoon/bassoon-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -134,7 +134,7 @@ tune=-13
 offset=101000
 
 <region>
-sample=../Samples/bassoon/bassoon-a#4.wav
+sample=../Samples/Bassoon/bassoon-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -142,7 +142,7 @@ tune=-9
 offset=105000
 
 <region>
-sample=../Samples/bassoon/bassoon-c#5.wav
+sample=../Samples/Bassoon/bassoon-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/Clarinet Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/Clarinet Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/clarinet/clarinet-d3.wav
+sample=../Samples/Clarinet/clarinet-d3.wav
 lokey=d3
 hikey=d#3
 pitch_keycenter=d3
@@ -49,21 +49,21 @@ tune=3
 offset=93000
 
 <region>
-sample=../Samples/clarinet/clarinet-f3.wav
+sample=../Samples/Clarinet/clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
 offset=96000
 
 <region>
-sample=../Samples/clarinet/clarinet-g#3.wav
+sample=../Samples/Clarinet/clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
 offset=91000
 
 <region>
-sample=../Samples/clarinet/clarinet-b3.wav
+sample=../Samples/Clarinet/clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
@@ -71,7 +71,7 @@ tune=5
 offset=93000
 
 <region>
-sample=../Samples/clarinet/clarinet-d4.wav
+sample=../Samples/Clarinet/clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
@@ -79,14 +79,14 @@ tune=6
 offset=90000
 
 <region>
-sample=../Samples/clarinet/clarinet-f4.wav
+sample=../Samples/Clarinet/clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
 offset=85000
 
 <region>
-sample=../Samples/clarinet/clarinet-g#4.wav
+sample=../Samples/Clarinet/clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
@@ -94,42 +94,42 @@ tune=8
 offset=93000
 
 <region>
-sample=../Samples/clarinet/clarinet-b4.wav
+sample=../Samples/Clarinet/clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
 offset=97000
 
 <region>
-sample=../Samples/clarinet/clarinet-d5.wav
+sample=../Samples/Clarinet/clarinet-d5.wav
 lokey=c#5
 hikey=d#5
 pitch_keycenter=d5
 offset=88000
 
 <region>
-sample=../Samples/clarinet/clarinet-f5.wav
+sample=../Samples/Clarinet/clarinet-f5.wav
 lokey=e5
 hikey=f#5
 pitch_keycenter=f5
 offset=88000
 
 <region>
-sample=../Samples/clarinet/clarinet-g#5.wav
+sample=../Samples/Clarinet/clarinet-g#5.wav
 lokey=g5
 hikey=a5
 pitch_keycenter=g#5
 offset=81000
 
 <region>
-sample=../Samples/clarinet/clarinet-b5.wav
+sample=../Samples/Clarinet/clarinet-b5.wav
 lokey=a#5
 hikey=c6
 pitch_keycenter=b5
 offset=87000
 
 <region>
-sample=../Samples/clarinet/clarinet-d6.wav
+sample=../Samples/Clarinet/clarinet-d6.wav
 lokey=c#6
 hikey=d6
 pitch_keycenter=d6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/Contrabassoon Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/Contrabassoon Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#0.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#0.wav
 lokey=a#0
 hikey=b0
 pitch_keycenter=a#0
@@ -49,7 +49,7 @@ tune=-20
 offset=54000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#1.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#1.wav
 lokey=c1
 hikey=d1
 pitch_keycenter=c#1
@@ -57,14 +57,14 @@ tune=-16
 offset=63000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e1.wav
+sample=../Samples/Contrabassoon/contrabassoon-e1.wav
 lokey=d#1
 hikey=f1
 pitch_keycenter=e1
 offset=64000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g1.wav
+sample=../Samples/Contrabassoon/contrabassoon-g1.wav
 lokey=f#1
 hikey=g#1
 pitch_keycenter=g1
@@ -72,7 +72,7 @@ tune=-11
 offset=58000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#1.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#1.wav
 lokey=a1
 hikey=b1
 pitch_keycenter=a#1
@@ -81,21 +81,21 @@ volume=2
 offset=53000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#2.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
 offset=52000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e2.wav
+sample=../Samples/Contrabassoon/contrabassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
 offset=72000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g2.wav
+sample=../Samples/Contrabassoon/contrabassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
@@ -104,7 +104,7 @@ volume=2
 offset=62000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#2.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
@@ -114,7 +114,7 @@ ampeg_sustain=0
 ampeg_decay=0.8
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#3.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
@@ -122,7 +122,7 @@ tune=-13
 offset=58000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e3.wav
+sample=../Samples/Contrabassoon/contrabassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
@@ -133,7 +133,7 @@ ampeg_sustain=0
 ampeg_decay=0.4
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g3.wav
+sample=../Samples/Contrabassoon/contrabassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -142,7 +142,7 @@ volume=-1
 offset=53000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#3.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#3.wav
 lokey=a3
 hikey=a#3
 pitch_keycenter=a#3

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/Oboe Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/Oboe Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/oboe/oboe-a#3.wav
+sample=../Samples/Oboe/oboe-a#3.wav
 lokey=a#3
 hikey=b3
 pitch_keycenter=a#3
@@ -49,7 +49,7 @@ tune=-8
 offset=59000
 
 <region>
-sample=../Samples/oboe/oboe-c#4.wav
+sample=../Samples/Oboe/oboe-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -57,7 +57,7 @@ tune=-9
 offset=53000
 
 <region>
-sample=../Samples/oboe/oboe-e4.wav
+sample=../Samples/Oboe/oboe-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
@@ -65,7 +65,7 @@ tune=-14
 offset=60000
 
 <region>
-sample=../Samples/oboe/oboe-g4.wav
+sample=../Samples/Oboe/oboe-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -73,7 +73,7 @@ tune=-10
 offset=57000
 
 <region>
-sample=../Samples/oboe/oboe-a#4.wav
+sample=../Samples/Oboe/oboe-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -81,14 +81,14 @@ tune=-5
 offset=63000
 
 <region>
-sample=../Samples/oboe/oboe-c#5.wav
+sample=../Samples/Oboe/oboe-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 offset=59000
 
 <region>
-sample=../Samples/oboe/oboe-e5.wav
+sample=../Samples/Oboe/oboe-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
@@ -97,7 +97,7 @@ volume=2
 offset=62000
 
 <region>
-sample=../Samples/oboe/oboe-g5.wav
+sample=../Samples/Oboe/oboe-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -105,7 +105,7 @@ tune=-20
 offset=75000
 
 <region>
-sample=../Samples/oboe/oboe-a#5.wav
+sample=../Samples/Oboe/oboe-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
@@ -113,7 +113,7 @@ tune=-22
 offset=66000
 
 <region>
-sample=../Samples/oboe/oboe-c6.wav
+sample=../Samples/Oboe/oboe-c6.wav
 lokey=c6
 hikey=d#6
 pitch_keycenter=c6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/alto-flute-solo-staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/alto-flute-solo-staccato.sfz
@@ -6,7 +6,7 @@
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-g3.wav
+sample=../Samples/Alto flute/alto_flute-g3.wav
 lokey=g3
 hikey=g#3
 pitch_keycenter=g3
@@ -48,7 +48,7 @@ cutoff=1000
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-a#3.wav
+sample=../Samples/Alto flute/alto_flute-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -91,7 +91,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-c#4.wav
+sample=../Samples/Alto flute/alto_flute-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -134,7 +134,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-e4.wav
+sample=../Samples/Alto flute/alto_flute-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
@@ -177,7 +177,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-g4.wav
+sample=../Samples/Alto flute/alto_flute-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -220,7 +220,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-a#4.wav
+sample=../Samples/Alto flute/alto_flute-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -264,7 +264,7 @@ cutoff=1000
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-c#5.wav
+sample=../Samples/Alto flute/alto_flute-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
@@ -306,7 +306,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-e5.wav
+sample=../Samples/Alto flute/alto_flute-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
@@ -348,7 +348,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-g5.wav
+sample=../Samples/Alto flute/alto_flute-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -390,7 +390,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-a#5.wav
+sample=../Samples/Alto flute/alto_flute-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
@@ -433,7 +433,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-c#6.wav
+sample=../Samples/Alto flute/alto_flute-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -476,7 +476,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-e6.wav
+sample=../Samples/Alto flute/alto_flute-e6.wav
 lokey=d#6
 hikey=f6
 pitch_keycenter=e6
@@ -518,7 +518,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-g6.wav
+sample=../Samples/Alto flute/alto_flute-g6.wav
 lokey=f#6
 hikey=g6
 pitch_keycenter=g6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/alto-flute-solo-sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/alto-flute-solo-sustain.sfz
@@ -1,11 +1,11 @@
 <region>
-sample=../Samples/alto flute/alto_flute-g3.wav
+sample=../Samples/Alto flute/alto_flute-g3.wav
 lokey=g3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/alto flute/alto_flute-a#3.wav
+sample=../Samples/Alto flute/alto_flute-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -14,7 +14,7 @@ ampeg_attack=0.07
 offset=7000
 
 <region>
-sample=../Samples/alto flute/alto_flute-c#4.wav
+sample=../Samples/Alto flute/alto_flute-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -22,7 +22,7 @@ tune=11
 volume=2
 
 <region>
-sample=../Samples/alto flute/alto_flute-e4.wav
+sample=../Samples/Alto flute/alto_flute-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
@@ -30,7 +30,7 @@ tune=-13
 volume=-1
 
 <region>
-sample=../Samples/alto flute/alto_flute-g4.wav
+sample=../Samples/Alto flute/alto_flute-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -38,35 +38,35 @@ tune=-22
 ampeg_attack=0.05
 
 <region>
-sample=../Samples/alto flute/alto_flute-a#4.wav
+sample=../Samples/Alto flute/alto_flute-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 volume=1
 
 <region>
-sample=../Samples/alto flute/alto_flute-c#5.wav
+sample=../Samples/Alto flute/alto_flute-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 tune=-6
 
 <region>
-sample=../Samples/alto flute/alto_flute-e5.wav
+sample=../Samples/Alto flute/alto_flute-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
 tune=-23
 
 <region>
-sample=../Samples/alto flute/alto_flute-g5.wav
+sample=../Samples/Alto flute/alto_flute-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
 tune=-32
 
 <region>
-sample=../Samples/alto flute/alto_flute-a#5.wav
+sample=../Samples/Alto flute/alto_flute-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
@@ -74,7 +74,7 @@ tune=-30
 volume=1
 
 <region>
-sample=../Samples/alto flute/alto_flute-c#6.wav
+sample=../Samples/Alto flute/alto_flute-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -82,14 +82,14 @@ tune=-28
 volume=2
 
 <region>
-sample=../Samples/alto flute/alto_flute-e6.wav
+sample=../Samples/Alto flute/alto_flute-e6.wav
 lokey=d#6
 hikey=f6
 pitch_keycenter=e6
 tune=-26
 
 <region>
-sample=../Samples/alto flute/alto_flute-g6.wav
+sample=../Samples/Alto flute/alto_flute-g6.wav
 lokey=f#6
 hikey=g6
 pitch_keycenter=g6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/bass-clarinet-solo-offset-attacks.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/bass-clarinet-solo-offset-attacks.sfz
@@ -1,34 +1,34 @@
 // This version of the file corrects for bad attacks.
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d2.wav
 lokey=d2
 hikey=d#2
 pitch_keycenter=d2
 tune=25
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f2.wav
 lokey=e2
 hikey=f#2
 pitch_keycenter=f2
 tune=6
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#2.wav
 lokey=g2
 hikey=a2
 pitch_keycenter=g#2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b2.wav
 lokey=a#2
 hikey=c3
 pitch_keycenter=b2
 tune=10
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d3.wav
 lokey=c#3
 hikey=d#3
 pitch_keycenter=d3
@@ -37,14 +37,14 @@ offset=4000
 ampeg_attack=0.1
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
 tune=8
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
@@ -53,7 +53,7 @@ offset=1000
 ampeg_attack=0.03
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
@@ -61,7 +61,7 @@ tune=7
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
@@ -69,7 +69,7 @@ tune=4
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
@@ -77,21 +77,21 @@ tune=15
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
 ampeg_attack=0.1
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
 tune=3
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d5.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d5.wav
 lokey=c#5
 hikey=d5
 pitch_keycenter=d5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/bass-clarinet-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/bass-clarinet-solo.sfz
@@ -1,53 +1,53 @@
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d2.wav
 lokey=d2
 hikey=d#2
 pitch_keycenter=d2
 tune=25
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f2.wav
 lokey=e2
 hikey=f#2
 pitch_keycenter=f2
 tune=6
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#2.wav
 lokey=g2
 hikey=a2
 pitch_keycenter=g#2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b2.wav
 lokey=a#2
 hikey=c3
 pitch_keycenter=b2
 tune=10
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d3.wav
 lokey=c#3
 hikey=d#3
 pitch_keycenter=d3
 tune=5
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
 tune=8
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
 tune=23
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
@@ -55,7 +55,7 @@ tune=7
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
@@ -63,7 +63,7 @@ tune=4
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
@@ -71,21 +71,21 @@ tune=15
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
 ampeg_attack=0.1
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
 tune=3
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d5.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d5.wav
 lokey=c#5
 hikey=d5
 pitch_keycenter=d5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/bassoon-solo-offset-attacks.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/bassoon-solo-offset-attacks.sfz
@@ -1,95 +1,95 @@
 // This version of the file corrects for bad attacks.
 
 <region>
-sample=../Samples/bassoon/bassoon-a#1.wav
+sample=../Samples/Bassoon/bassoon-a#1.wav
 lokey=a#1
 hikey=b1
 pitch_keycenter=a#1
 tune=-13
 
 <region>
-sample=../Samples/bassoon/bassoon-c#2.wav
+sample=../Samples/Bassoon/bassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
 tune=-17
 
 <region>
-sample=../Samples/bassoon/bassoon-e2.wav
+sample=../Samples/Bassoon/bassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
 tune=-12
 
 <region>
-sample=../Samples/bassoon/bassoon-g2.wav
+sample=../Samples/Bassoon/bassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 
 <region>
-sample=../Samples/bassoon/bassoon-a#2.wav
+sample=../Samples/Bassoon/bassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/bassoon/bassoon-c#3.wav
+sample=../Samples/Bassoon/bassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 tune=-12
 
 <region>
-sample=../Samples/bassoon/bassoon-e3.wav
+sample=../Samples/Bassoon/bassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 tune=-11
 
 <region>
-sample=../Samples/bassoon/bassoon-g3.wav
+sample=../Samples/Bassoon/bassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 tune=-5
 
 <region>
-sample=../Samples/bassoon/bassoon-a#3.wav
+sample=../Samples/Bassoon/bassoon-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 tune=-4
 
 <region>
-sample=../Samples/bassoon/bassoon-c#4.wav
+sample=../Samples/Bassoon/bassoon-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=5
 
 <region>
-sample=../Samples/bassoon/bassoon-e4.wav
+sample=../Samples/Bassoon/bassoon-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/bassoon/bassoon-g4.wav
+sample=../Samples/Bassoon/bassoon-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-13
 
 <region>
-sample=../Samples/bassoon/bassoon-a#4.wav
+sample=../Samples/Bassoon/bassoon-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 tune=-9
 
 <region>
-sample=../Samples/bassoon/bassoon-c#5.wav
+sample=../Samples/Bassoon/bassoon-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/bassoon-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/bassoon-solo.sfz
@@ -1,94 +1,94 @@
 
 <region>
-sample=../Samples/bassoon/bassoon-a#1.wav
+sample=../Samples/Bassoon/bassoon-a#1.wav
 lokey=a#1
 hikey=b1
 pitch_keycenter=a#1
 tune=-13
 
 <region>
-sample=../Samples/bassoon/bassoon-c#2.wav
+sample=../Samples/Bassoon/bassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
 tune=-17
 
 <region>
-sample=../Samples/bassoon/bassoon-e2.wav
+sample=../Samples/Bassoon/bassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
 tune=-12
 
 <region>
-sample=../Samples/bassoon/bassoon-g2.wav
+sample=../Samples/Bassoon/bassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 
 <region>
-sample=../Samples/bassoon/bassoon-a#2.wav
+sample=../Samples/Bassoon/bassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/bassoon/bassoon-c#3.wav
+sample=../Samples/Bassoon/bassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 tune=-12
 
 <region>
-sample=../Samples/bassoon/bassoon-e3.wav
+sample=../Samples/Bassoon/bassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 tune=-11
 
 <region>
-sample=../Samples/bassoon/bassoon-g3.wav
+sample=../Samples/Bassoon/bassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 tune=-5
 
 <region>
-sample=../Samples/bassoon/bassoon-a#3.wav
+sample=../Samples/Bassoon/bassoon-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 tune=-4
 
 <region>
-sample=../Samples/bassoon/bassoon-c#4.wav
+sample=../Samples/Bassoon/bassoon-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=5
 
 <region>
-sample=../Samples/bassoon/bassoon-e4.wav
+sample=../Samples/Bassoon/bassoon-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/bassoon/bassoon-g4.wav
+sample=../Samples/Bassoon/bassoon-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-13
 
 <region>
-sample=../Samples/bassoon/bassoon-a#4.wav
+sample=../Samples/Bassoon/bassoon-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 tune=-9
 
 <region>
-sample=../Samples/bassoon/bassoon-c#5.wav
+sample=../Samples/Bassoon/bassoon-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/clarinet-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/clarinet-solo.sfz
@@ -1,84 +1,84 @@
 
 <region>
-sample=../Samples/clarinet/clarinet-d3.wav
+sample=../Samples/Clarinet/clarinet-d3.wav
 lokey=d3
 hikey=d#3
 pitch_keycenter=d3
 tune=3
 
 <region>
-sample=../Samples/clarinet/clarinet-f3.wav
+sample=../Samples/Clarinet/clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
 
 <region>
-sample=../Samples/clarinet/clarinet-g#3.wav
+sample=../Samples/Clarinet/clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
 
 <region>
-sample=../Samples/clarinet/clarinet-b3.wav
+sample=../Samples/Clarinet/clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
 tune=5
 
 <region>
-sample=../Samples/clarinet/clarinet-d4.wav
+sample=../Samples/Clarinet/clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
 tune=6
 
 <region>
-sample=../Samples/clarinet/clarinet-f4.wav
+sample=../Samples/Clarinet/clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
 volume=-1
 
 <region>
-sample=../Samples/clarinet/clarinet-g#4.wav
+sample=../Samples/Clarinet/clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
 tune=8
 
 <region>
-sample=../Samples/clarinet/clarinet-b4.wav
+sample=../Samples/Clarinet/clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
 
 <region>
-sample=../Samples/clarinet/clarinet-d5.wav
+sample=../Samples/Clarinet/clarinet-d5.wav
 lokey=c#5
 hikey=d#5
 pitch_keycenter=d5
 
 <region>
-sample=../Samples/clarinet/clarinet-f5.wav
+sample=../Samples/Clarinet/clarinet-f5.wav
 lokey=e5
 hikey=f#5
 pitch_keycenter=f5
 
 <region>
-sample=../Samples/clarinet/clarinet-g#5.wav
+sample=../Samples/Clarinet/clarinet-g#5.wav
 lokey=g5
 hikey=a5
 pitch_keycenter=g#5
 
 <region>
-sample=../Samples/clarinet/clarinet-b5.wav
+sample=../Samples/Clarinet/clarinet-b5.wav
 lokey=a#5
 hikey=c6
 pitch_keycenter=b5
 volume=1
 
 <region>
-sample=../Samples/clarinet/clarinet-d6.wav
+sample=../Samples/Clarinet/clarinet-d6.wav
 lokey=c#6
 hikey=d6
 pitch_keycenter=d6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/contrabassoon-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/contrabassoon-solo.sfz
@@ -1,32 +1,32 @@
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#0.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#0.wav
 lokey=a#0
 hikey=b0
 pitch_keycenter=a#0
 tune=-20
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#1.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#1.wav
 lokey=c1
 hikey=d1
 pitch_keycenter=c#1
 tune=-16
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e1.wav
+sample=../Samples/Contrabassoon/contrabassoon-e1.wav
 lokey=d#1
 hikey=f1
 pitch_keycenter=e1
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g1.wav
+sample=../Samples/Contrabassoon/contrabassoon-g1.wav
 lokey=f#1
 hikey=g#1
 pitch_keycenter=g1
 tune=-11
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#1.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#1.wav
 lokey=a1
 hikey=b1
 pitch_keycenter=a#1
@@ -34,19 +34,19 @@ tune=-18
 volume=2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#2.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e2.wav
+sample=../Samples/Contrabassoon/contrabassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g2.wav
+sample=../Samples/Contrabassoon/contrabassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
@@ -54,21 +54,21 @@ tune=-16
 volume=2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#2.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 volume=2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#3.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 tune=-13
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e3.wav
+sample=../Samples/Contrabassoon/contrabassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
@@ -76,7 +76,7 @@ tune=-16
 volume=-1
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g3.wav
+sample=../Samples/Contrabassoon/contrabassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -84,7 +84,7 @@ tune=-7
 volume=-1
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#3.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#3.wav
 lokey=a3
 hikey=a#3
 pitch_keycenter=a#3

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/flute-solo-1-staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/flute-solo-1-staccato.sfz
@@ -1,5 +1,5 @@
 <group>
-sample=../Samples/flute/flute-c3.wav
+sample=../Samples/Flute/flute-c3.wav
 lokey=c4
 hikey=c#4
 pitch_keycenter=c4
@@ -42,7 +42,7 @@ cutoff=2000
 
 
 <group>
-sample=../Samples/flute/flute-d#3.wav
+sample=../Samples/Flute/flute-d#3.wav
 lokey=d4
 hikey=e4
 pitch_keycenter=d#4
@@ -84,7 +84,7 @@ cutoff=2000
 
 
 <group>
-sample=../Samples/flute/flute-f#3.wav
+sample=../Samples/Flute/flute-f#3.wav
 lokey=f4
 hikey=g4
 pitch_keycenter=f#4
@@ -126,7 +126,7 @@ cutoff=2000
 
 
 <group>
-sample=../Samples/flute/flute-a3.wav
+sample=../Samples/Flute/flute-a3.wav
 lokey=g#4
 hikey=a#4
 pitch_keycenter=a4
@@ -166,7 +166,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-c4.wav
+sample=../Samples/Flute/flute-c4.wav
 lokey=b4
 hikey=c#5
 pitch_keycenter=c5
@@ -207,7 +207,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-d#4.wav
+sample=../Samples/Flute/flute-d#4.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
@@ -248,7 +248,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-f#4.wav
+sample=../Samples/Flute/flute-f#4.wav
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
@@ -289,7 +289,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-a4.wav
+sample=../Samples/Flute/flute-a4.wav
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
@@ -331,7 +331,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-c5.wav
+sample=../Samples/Flute/flute-c5.wav
 lokey=b5
 hikey=c#6
 pitch_keycenter=c6
@@ -373,7 +373,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-d#5.wav
+sample=../Samples/Flute/flute-d#5.wav
 lokey=d6
 hikey=e6
 pitch_keycenter=d#6
@@ -415,7 +415,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-f#5.wav
+sample=../Samples/Flute/flute-f#5.wav
 lokey=f6
 hikey=g6
 pitch_keycenter=f#6
@@ -457,7 +457,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-a5.wav
+sample=../Samples/Flute/flute-a5.wav
 lokey=g#6
 hikey=a#6
 pitch_keycenter=a6
@@ -498,7 +498,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-c6.wav
+sample=../Samples/Flute/flute-c6.wav
 lokey=b6
 hikey=c7
 pitch_keycenter=c7

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/flute-solo-1-sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/flute-solo-1-sustain.sfz
@@ -1,65 +1,65 @@
 <region>
-sample=../Samples/flute/flute-c3.wav
+sample=../Samples/Flute/flute-c3.wav
 lokey=c4
 hikey=c#4
 pitch_keycenter=c4
 volume=-1
 
 <region>
-sample=../Samples/flute/flute-d#3.wav
+sample=../Samples/Flute/flute-d#3.wav
 lokey=d4
 hikey=e4
 pitch_keycenter=d#4
 
 <region>
-sample=../Samples/flute/flute-f#3.wav
+sample=../Samples/Flute/flute-f#3.wav
 lokey=f4
 hikey=g4
 pitch_keycenter=f#4
 
 <region>
-sample=../Samples/flute/flute-a3.wav
+sample=../Samples/Flute/flute-a3.wav
 lokey=g#4
 hikey=a#4
 pitch_keycenter=a4
 
 <region>
-sample=../Samples/flute/flute-c4.wav
+sample=../Samples/Flute/flute-c4.wav
 lokey=b4
 hikey=c#5
 pitch_keycenter=c5
 tune=-16
 
 <region>
-sample=../Samples/flute/flute-d#4.wav
+sample=../Samples/Flute/flute-d#4.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
 tune=-7
 
 <region>
-sample=../Samples/flute/flute-f#4.wav
+sample=../Samples/Flute/flute-f#4.wav
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
 tune=-4
 
 <region>
-sample=../Samples/flute/flute-a4.wav
+sample=../Samples/Flute/flute-a4.wav
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
 tune=-17
 
 <region>
-sample=../Samples/flute/flute-c5.wav
+sample=../Samples/Flute/flute-c5.wav
 lokey=b5
 hikey=c#6
 pitch_keycenter=c6
 tune=-4
 
 <region>
-sample=../Samples/flute/flute-d#5.wav
+sample=../Samples/Flute/flute-d#5.wav
 lokey=d6
 hikey=e6
 pitch_keycenter=d#6
@@ -67,7 +67,7 @@ volume=-2
 tune=-8
 
 <region>
-sample=../Samples/flute/flute-f#5.wav
+sample=../Samples/Flute/flute-f#5.wav
 lokey=f6
 hikey=g6
 pitch_keycenter=f#6
@@ -75,14 +75,14 @@ volume=-3
 tune=-16
 
 <region>
-sample=../Samples/flute/flute-a5.wav
+sample=../Samples/Flute/flute-a5.wav
 lokey=g#6
 hikey=a#6
 pitch_keycenter=a6
 tune=-17
 
 <region>
-sample=../Samples/flute/flute-c6.wav
+sample=../Samples/Flute/flute-c6.wav
 lokey=b6
 hikey=c7
 pitch_keycenter=c7

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/oboe-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/oboe-solo.sfz
@@ -1,33 +1,33 @@
 <region>
-sample=../Samples/oboe/oboe-a#3.wav
+sample=../Samples/Oboe/oboe-a#3.wav
 lokey=a#3
 hikey=b3
 pitch_keycenter=a#3
 tune=-8
 
 <region>
-sample=../Samples/oboe/oboe-c#4.wav
+sample=../Samples/Oboe/oboe-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=-9
 
 <region>
-sample=../Samples/oboe/oboe-e4.wav
+sample=../Samples/Oboe/oboe-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 tune=-14
 
 <region>
-sample=../Samples/oboe/oboe-g4.wav
+sample=../Samples/Oboe/oboe-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-10
 
 <region>
-sample=../Samples/oboe/oboe-a#4.wav
+sample=../Samples/Oboe/oboe-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -35,14 +35,14 @@ tune=-5
 volume=-2
 
 <region>
-sample=../Samples/oboe/oboe-c#5.wav
+sample=../Samples/Oboe/oboe-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 volume=-2
 
 <region>
-sample=../Samples/oboe/oboe-e5.wav
+sample=../Samples/Oboe/oboe-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
@@ -50,21 +50,21 @@ tune=-15
 volume=4
 
 <region>
-sample=../Samples/oboe/oboe-g5.wav
+sample=../Samples/Oboe/oboe-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
 tune=-20
 
 <region>
-sample=../Samples/oboe/oboe-a#5.wav
+sample=../Samples/Oboe/oboe-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 tune=-22
 
 <region>
-sample=../Samples/oboe/oboe-c6.wav
+sample=../Samples/Oboe/oboe-c6.wav
 lokey=c6
 hikey=d#6
 pitch_keycenter=c6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/piccolo-solo-staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/piccolo-solo-staccato.sfz
@@ -1,5 +1,5 @@
 <group>
-sample=../Samples/piccolo/piccolo-c4.wav
+sample=../Samples/Piccolo/piccolo-c4.wav
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
@@ -39,7 +39,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-d#4.wav
+sample=../Samples/Piccolo/piccolo-d#4.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
@@ -79,7 +79,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-f#4.wav
+sample=../Samples/Piccolo/piccolo-f#4.wav
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
@@ -119,7 +119,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-a4.wav
+sample=../Samples/Piccolo/piccolo-a4.wav
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
@@ -159,7 +159,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-c5.wav
+sample=../Samples/Piccolo/piccolo-c5.wav
 lokey=b5
 hikey=c#6
 pitch_keycenter=c6
@@ -199,7 +199,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-d#5.wav
+sample=../Samples/Piccolo/piccolo-d#5.wav
 lokey=d6
 hikey=e6
 pitch_keycenter=d#6
@@ -239,7 +239,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-f#5.wav
+sample=../Samples/Piccolo/piccolo-f#5.wav
 lokey=f6
 hikey=g6
 pitch_keycenter=f#6
@@ -279,7 +279,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-a5.wav
+sample=../Samples/Piccolo/piccolo-a5.wav
 lokey=g#6
 hikey=a#6
 pitch_keycenter=a6
@@ -320,7 +320,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-c6.wav
+sample=../Samples/Piccolo/piccolo-c6.wav
 lokey=b6
 hikey=c#7
 pitch_keycenter=c7
@@ -360,7 +360,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-d#6.wav
+sample=../Samples/Piccolo/piccolo-d#6.wav
 lokey=d7
 hikey=e7
 pitch_keycenter=d#7
@@ -400,7 +400,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-f#6.wav
+sample=../Samples/Piccolo/piccolo-f#6.wav
 lokey=f7
 hikey=g7
 pitch_keycenter=f#7

--- a/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/piccolo-solo-sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Notation/includes/piccolo-solo-sustain.sfz
@@ -1,66 +1,66 @@
 <region>
-sample=../Samples/piccolo/piccolo-c4.wav
+sample=../Samples/Piccolo/piccolo-c4.wav
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
 
 <region>
-sample=../Samples/piccolo/piccolo-d#4.wav
+sample=../Samples/Piccolo/piccolo-d#4.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
 
 <region>
-sample=../Samples/piccolo/piccolo-f#4.wav
+sample=../Samples/Piccolo/piccolo-f#4.wav
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
 
 <region>
-sample=../Samples/piccolo/piccolo-a4.wav
+sample=../Samples/Piccolo/piccolo-a4.wav
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
 
 <region>
-sample=../Samples/piccolo/piccolo-c5.wav
+sample=../Samples/Piccolo/piccolo-c5.wav
 lokey=b5
 hikey=c#6
 pitch_keycenter=c6
 
 <region>
-sample=../Samples/piccolo/piccolo-d#5.wav
+sample=../Samples/Piccolo/piccolo-d#5.wav
 lokey=d6
 hikey=e6
 pitch_keycenter=d#6
 
 <region>
-sample=../Samples/piccolo/piccolo-f#5.wav
+sample=../Samples/Piccolo/piccolo-f#5.wav
 lokey=f6
 hikey=g6
 pitch_keycenter=f#6
 
 <region>
-sample=../Samples/piccolo/piccolo-a5.wav
+sample=../Samples/Piccolo/piccolo-a5.wav
 lokey=g#6
 hikey=a#6
 pitch_keycenter=a6
 volume=-28
 
 <region>
-sample=../Samples/piccolo/piccolo-c6.wav
+sample=../Samples/Piccolo/piccolo-c6.wav
 lokey=b6
 hikey=c#7
 pitch_keycenter=c7
 
 <region>
-sample=../Samples/piccolo/piccolo-d#6.wav
+sample=../Samples/Piccolo/piccolo-d#6.wav
 lokey=d7
 hikey=e7
 pitch_keycenter=d#7
 
 <region>
-sample=../Samples/piccolo/piccolo-f#6.wav
+sample=../Samples/Piccolo/piccolo-f#6.wav
 lokey=f7
 hikey=g7
 pitch_keycenter=f#7

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/Bass Clarinet Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/Bass Clarinet Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d2.wav
 lokey=d2
 hikey=d#2
 pitch_keycenter=d2
@@ -49,7 +49,7 @@ tune=25
 offset=90000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f2.wav
 lokey=e2
 hikey=f#2
 pitch_keycenter=f2
@@ -57,14 +57,14 @@ tune=6
 offset=94000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#2.wav
 lokey=g2
 hikey=a2
 pitch_keycenter=g#2
 offset=88000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b2.wav
 lokey=a#2
 hikey=c3
 pitch_keycenter=b2
@@ -72,7 +72,7 @@ tune=10
 offset=91000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d3.wav
 lokey=c#3
 hikey=d#3
 pitch_keycenter=d3
@@ -80,7 +80,7 @@ tune=5
 offset=94000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
@@ -88,7 +88,7 @@ tune=8
 offset=88000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
@@ -96,7 +96,7 @@ tune=23
 offset=85000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
@@ -104,7 +104,7 @@ tune=7
 offset=88000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
@@ -112,7 +112,7 @@ tune=4
 offset=94000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
@@ -120,7 +120,7 @@ tune=15
 offset=84000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
@@ -128,7 +128,7 @@ ampeg_attack=0.1
 offset=91000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
@@ -136,7 +136,7 @@ tune=3
 offset=87000
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d5.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d5.wav
 lokey=c#5
 hikey=d5
 pitch_keycenter=d5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/Bassoon Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/Bassoon Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/bassoon/bassoon-a#1.wav
+sample=../Samples/Bassoon/bassoon-a#1.wav
 lokey=a#1
 hikey=b1
 pitch_keycenter=a#1
@@ -49,7 +49,7 @@ tune=-13
 offset=85000
 
 <region>
-sample=../Samples/bassoon/bassoon-c#2.wav
+sample=../Samples/Bassoon/bassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
@@ -57,7 +57,7 @@ tune=-17
 offset=90000
 
 <region>
-sample=../Samples/bassoon/bassoon-e2.wav
+sample=../Samples/Bassoon/bassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
@@ -65,21 +65,21 @@ tune=-12
 offset=95000
 
 <region>
-sample=../Samples/bassoon/bassoon-g2.wav
+sample=../Samples/Bassoon/bassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 offset=95000
 
 <region>
-sample=../Samples/bassoon/bassoon-a#2.wav
+sample=../Samples/Bassoon/bassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 offset=96000
 
 <region>
-sample=../Samples/bassoon/bassoon-c#3.wav
+sample=../Samples/Bassoon/bassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
@@ -87,7 +87,7 @@ tune=-12
 offset=85000
 
 <region>
-sample=../Samples/bassoon/bassoon-e3.wav
+sample=../Samples/Bassoon/bassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
@@ -95,7 +95,7 @@ tune=-11
 offset=97000
 
 <region>
-sample=../Samples/bassoon/bassoon-g3.wav
+sample=../Samples/Bassoon/bassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -103,7 +103,7 @@ tune=-5
 offset=91000
 
 <region>
-sample=../Samples/bassoon/bassoon-a#3.wav
+sample=../Samples/Bassoon/bassoon-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -111,7 +111,7 @@ tune=-4
 offset=88500
 
 <region>
-sample=../Samples/bassoon/bassoon-c#4.wav
+sample=../Samples/Bassoon/bassoon-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -119,14 +119,14 @@ tune=5
 offset=112000
 
 <region>
-sample=../Samples/bassoon/bassoon-e4.wav
+sample=../Samples/Bassoon/bassoon-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 offset=101000
 
 <region>
-sample=../Samples/bassoon/bassoon-g4.wav
+sample=../Samples/Bassoon/bassoon-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -134,7 +134,7 @@ tune=-13
 offset=101000
 
 <region>
-sample=../Samples/bassoon/bassoon-a#4.wav
+sample=../Samples/Bassoon/bassoon-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -142,7 +142,7 @@ tune=-9
 offset=105000
 
 <region>
-sample=../Samples/bassoon/bassoon-c#5.wav
+sample=../Samples/Bassoon/bassoon-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/Clarinet Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/Clarinet Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/clarinet/clarinet-d3.wav
+sample=../Samples/Clarinet/clarinet-d3.wav
 lokey=d3
 hikey=d#3
 pitch_keycenter=d3
@@ -49,21 +49,21 @@ tune=3
 offset=93000
 
 <region>
-sample=../Samples/clarinet/clarinet-f3.wav
+sample=../Samples/Clarinet/clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
 offset=96000
 
 <region>
-sample=../Samples/clarinet/clarinet-g#3.wav
+sample=../Samples/Clarinet/clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
 offset=91000
 
 <region>
-sample=../Samples/clarinet/clarinet-b3.wav
+sample=../Samples/Clarinet/clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
@@ -71,7 +71,7 @@ tune=5
 offset=93000
 
 <region>
-sample=../Samples/clarinet/clarinet-d4.wav
+sample=../Samples/Clarinet/clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
@@ -79,14 +79,14 @@ tune=6
 offset=90000
 
 <region>
-sample=../Samples/clarinet/clarinet-f4.wav
+sample=../Samples/Clarinet/clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
 offset=85000
 
 <region>
-sample=../Samples/clarinet/clarinet-g#4.wav
+sample=../Samples/Clarinet/clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
@@ -94,42 +94,42 @@ tune=8
 offset=93000
 
 <region>
-sample=../Samples/clarinet/clarinet-b4.wav
+sample=../Samples/Clarinet/clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
 offset=97000
 
 <region>
-sample=../Samples/clarinet/clarinet-d5.wav
+sample=../Samples/Clarinet/clarinet-d5.wav
 lokey=c#5
 hikey=d#5
 pitch_keycenter=d5
 offset=88000
 
 <region>
-sample=../Samples/clarinet/clarinet-f5.wav
+sample=../Samples/Clarinet/clarinet-f5.wav
 lokey=e5
 hikey=f#5
 pitch_keycenter=f5
 offset=88000
 
 <region>
-sample=../Samples/clarinet/clarinet-g#5.wav
+sample=../Samples/Clarinet/clarinet-g#5.wav
 lokey=g5
 hikey=a5
 pitch_keycenter=g#5
 offset=81000
 
 <region>
-sample=../Samples/clarinet/clarinet-b5.wav
+sample=../Samples/Clarinet/clarinet-b5.wav
 lokey=a#5
 hikey=c6
 pitch_keycenter=b5
 offset=87000
 
 <region>
-sample=../Samples/clarinet/clarinet-d6.wav
+sample=../Samples/Clarinet/clarinet-d6.wav
 lokey=c#6
 hikey=d6
 pitch_keycenter=d6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/Contrabassoon Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/Contrabassoon Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#0.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#0.wav
 lokey=a#0
 hikey=b0
 pitch_keycenter=a#0
@@ -49,7 +49,7 @@ tune=-20
 offset=54000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#1.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#1.wav
 lokey=c1
 hikey=d1
 pitch_keycenter=c#1
@@ -57,14 +57,14 @@ tune=-16
 offset=63000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e1.wav
+sample=../Samples/Contrabassoon/contrabassoon-e1.wav
 lokey=d#1
 hikey=f1
 pitch_keycenter=e1
 offset=64000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g1.wav
+sample=../Samples/Contrabassoon/contrabassoon-g1.wav
 lokey=f#1
 hikey=g#1
 pitch_keycenter=g1
@@ -72,7 +72,7 @@ tune=-11
 offset=58000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#1.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#1.wav
 lokey=a1
 hikey=b1
 pitch_keycenter=a#1
@@ -81,21 +81,21 @@ volume=2
 offset=53000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#2.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
 offset=52000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e2.wav
+sample=../Samples/Contrabassoon/contrabassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
 offset=72000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g2.wav
+sample=../Samples/Contrabassoon/contrabassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
@@ -104,7 +104,7 @@ volume=2
 offset=62000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#2.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
@@ -114,7 +114,7 @@ ampeg_sustain=0
 ampeg_decay=0.8
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#3.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
@@ -122,7 +122,7 @@ tune=-13
 offset=58000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e3.wav
+sample=../Samples/Contrabassoon/contrabassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
@@ -133,7 +133,7 @@ ampeg_sustain=0
 ampeg_decay=0.4
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g3.wav
+sample=../Samples/Contrabassoon/contrabassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -142,7 +142,7 @@ volume=-1
 offset=53000
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#3.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#3.wav
 lokey=a3
 hikey=a#3
 pitch_keycenter=a#3

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/Oboe Solo Staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/Oboe Solo Staccato.sfz
@@ -41,7 +41,7 @@ ampeg_release=2
 loop_mode=one_shot
 
 <region>
-sample=../Samples/oboe/oboe-a#3.wav
+sample=../Samples/Oboe/oboe-a#3.wav
 lokey=a#3
 hikey=b3
 pitch_keycenter=a#3
@@ -49,7 +49,7 @@ tune=-8
 offset=59000
 
 <region>
-sample=../Samples/oboe/oboe-c#4.wav
+sample=../Samples/Oboe/oboe-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -57,7 +57,7 @@ tune=-9
 offset=53000
 
 <region>
-sample=../Samples/oboe/oboe-e4.wav
+sample=../Samples/Oboe/oboe-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
@@ -65,7 +65,7 @@ tune=-14
 offset=60000
 
 <region>
-sample=../Samples/oboe/oboe-g4.wav
+sample=../Samples/Oboe/oboe-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -73,7 +73,7 @@ tune=-10
 offset=57000
 
 <region>
-sample=../Samples/oboe/oboe-a#4.wav
+sample=../Samples/Oboe/oboe-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -81,14 +81,14 @@ tune=-5
 offset=63000
 
 <region>
-sample=../Samples/oboe/oboe-c#5.wav
+sample=../Samples/Oboe/oboe-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 offset=59000
 
 <region>
-sample=../Samples/oboe/oboe-e5.wav
+sample=../Samples/Oboe/oboe-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
@@ -97,7 +97,7 @@ volume=2
 offset=62000
 
 <region>
-sample=../Samples/oboe/oboe-g5.wav
+sample=../Samples/Oboe/oboe-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -105,7 +105,7 @@ tune=-20
 offset=75000
 
 <region>
-sample=../Samples/oboe/oboe-a#5.wav
+sample=../Samples/Oboe/oboe-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
@@ -113,7 +113,7 @@ tune=-22
 offset=66000
 
 <region>
-sample=../Samples/oboe/oboe-c6.wav
+sample=../Samples/Oboe/oboe-c6.wav
 lokey=c6
 hikey=d#6
 pitch_keycenter=c6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/alto-flute-solo-staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/alto-flute-solo-staccato.sfz
@@ -6,7 +6,7 @@
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-g3.wav
+sample=../Samples/Alto flute/alto_flute-g3.wav
 lokey=g3
 hikey=g#3
 pitch_keycenter=g3
@@ -48,7 +48,7 @@ cutoff=1000
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-a#3.wav
+sample=../Samples/Alto flute/alto_flute-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -91,7 +91,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-c#4.wav
+sample=../Samples/Alto flute/alto_flute-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -134,7 +134,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-e4.wav
+sample=../Samples/Alto flute/alto_flute-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
@@ -177,7 +177,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-g4.wav
+sample=../Samples/Alto flute/alto_flute-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -220,7 +220,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-a#4.wav
+sample=../Samples/Alto flute/alto_flute-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -264,7 +264,7 @@ cutoff=1000
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-c#5.wav
+sample=../Samples/Alto flute/alto_flute-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
@@ -306,7 +306,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-e5.wav
+sample=../Samples/Alto flute/alto_flute-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
@@ -348,7 +348,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-g5.wav
+sample=../Samples/Alto flute/alto_flute-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
@@ -390,7 +390,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-a#5.wav
+sample=../Samples/Alto flute/alto_flute-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
@@ -433,7 +433,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-c#6.wav
+sample=../Samples/Alto flute/alto_flute-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -476,7 +476,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-e6.wav
+sample=../Samples/Alto flute/alto_flute-e6.wav
 lokey=d#6
 hikey=f6
 pitch_keycenter=e6
@@ -518,7 +518,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/alto flute/alto_flute-g6.wav
+sample=../Samples/Alto flute/alto_flute-g6.wav
 lokey=f#6
 hikey=g6
 pitch_keycenter=g6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/alto-flute-solo-sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/alto-flute-solo-sustain.sfz
@@ -1,11 +1,11 @@
 <region>
-sample=../Samples/alto flute/alto_flute-g3.wav
+sample=../Samples/Alto flute/alto_flute-g3.wav
 lokey=g3
 hikey=g#3
 pitch_keycenter=g3
 
 <region>
-sample=../Samples/alto flute/alto_flute-a#3.wav
+sample=../Samples/Alto flute/alto_flute-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
@@ -14,7 +14,7 @@ ampeg_attack=0.07
 offset=7000
 
 <region>
-sample=../Samples/alto flute/alto_flute-c#4.wav
+sample=../Samples/Alto flute/alto_flute-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
@@ -22,7 +22,7 @@ tune=11
 volume=2
 
 <region>
-sample=../Samples/alto flute/alto_flute-e4.wav
+sample=../Samples/Alto flute/alto_flute-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
@@ -30,7 +30,7 @@ tune=-13
 volume=-1
 
 <region>
-sample=../Samples/alto flute/alto_flute-g4.wav
+sample=../Samples/Alto flute/alto_flute-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
@@ -38,35 +38,35 @@ tune=-22
 ampeg_attack=0.05
 
 <region>
-sample=../Samples/alto flute/alto_flute-a#4.wav
+sample=../Samples/Alto flute/alto_flute-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 volume=1
 
 <region>
-sample=../Samples/alto flute/alto_flute-c#5.wav
+sample=../Samples/Alto flute/alto_flute-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 tune=-6
 
 <region>
-sample=../Samples/alto flute/alto_flute-e5.wav
+sample=../Samples/Alto flute/alto_flute-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
 tune=-23
 
 <region>
-sample=../Samples/alto flute/alto_flute-g5.wav
+sample=../Samples/Alto flute/alto_flute-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
 tune=-32
 
 <region>
-sample=../Samples/alto flute/alto_flute-a#5.wav
+sample=../Samples/Alto flute/alto_flute-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
@@ -74,7 +74,7 @@ tune=-30
 volume=1
 
 <region>
-sample=../Samples/alto flute/alto_flute-c#6.wav
+sample=../Samples/Alto flute/alto_flute-c#6.wav
 lokey=c6
 hikey=d6
 pitch_keycenter=c#6
@@ -82,14 +82,14 @@ tune=-28
 volume=2
 
 <region>
-sample=../Samples/alto flute/alto_flute-e6.wav
+sample=../Samples/Alto flute/alto_flute-e6.wav
 lokey=d#6
 hikey=f6
 pitch_keycenter=e6
 tune=-26
 
 <region>
-sample=../Samples/alto flute/alto_flute-g6.wav
+sample=../Samples/Alto flute/alto_flute-g6.wav
 lokey=f#6
 hikey=g6
 pitch_keycenter=g6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/bass-clarinet-solo-offset-attacks.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/bass-clarinet-solo-offset-attacks.sfz
@@ -1,34 +1,34 @@
 // This version of the file corrects for bad attacks.
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d2.wav
 lokey=d2
 hikey=d#2
 pitch_keycenter=d2
 tune=25
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f2.wav
 lokey=e2
 hikey=f#2
 pitch_keycenter=f2
 tune=6
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#2.wav
 lokey=g2
 hikey=a2
 pitch_keycenter=g#2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b2.wav
 lokey=a#2
 hikey=c3
 pitch_keycenter=b2
 tune=10
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d3.wav
 lokey=c#3
 hikey=d#3
 pitch_keycenter=d3
@@ -37,14 +37,14 @@ offset=4000
 ampeg_attack=0.1
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
 tune=8
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
@@ -53,7 +53,7 @@ offset=1000
 ampeg_attack=0.03
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
@@ -61,7 +61,7 @@ tune=7
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
@@ -69,7 +69,7 @@ tune=4
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
@@ -77,21 +77,21 @@ tune=15
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
 ampeg_attack=0.1
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
 tune=3
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d5.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d5.wav
 lokey=c#5
 hikey=d5
 pitch_keycenter=d5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/bass-clarinet-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/bass-clarinet-solo.sfz
@@ -1,53 +1,53 @@
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d2.wav
 lokey=d2
 hikey=d#2
 pitch_keycenter=d2
 tune=25
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f2.wav
 lokey=e2
 hikey=f#2
 pitch_keycenter=f2
 tune=6
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#2.wav
 lokey=g2
 hikey=a2
 pitch_keycenter=g#2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b2.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b2.wav
 lokey=a#2
 hikey=c3
 pitch_keycenter=b2
 tune=10
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d3.wav
 lokey=c#3
 hikey=d#3
 pitch_keycenter=d3
 tune=5
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
 tune=8
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
 tune=23
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b3.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
@@ -55,7 +55,7 @@ tune=7
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
@@ -63,7 +63,7 @@ tune=4
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-f4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
@@ -71,21 +71,21 @@ tune=15
 volume=2
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-g#4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
 ampeg_attack=0.1
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-b4.wav
+sample=../Samples/Bass clarinet/bass_clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
 tune=3
 
 <region>
-sample=../Samples/bass clarinet/bass_clarinet-d5.wav
+sample=../Samples/Bass clarinet/bass_clarinet-d5.wav
 lokey=c#5
 hikey=d5
 pitch_keycenter=d5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/bassoon-solo-offset-attacks.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/bassoon-solo-offset-attacks.sfz
@@ -1,95 +1,95 @@
 // This version of the file corrects for bad attacks.
 
 <region>
-sample=../Samples/bassoon/bassoon-a#1.wav
+sample=../Samples/Bassoon/bassoon-a#1.wav
 lokey=a#1
 hikey=b1
 pitch_keycenter=a#1
 tune=-13
 
 <region>
-sample=../Samples/bassoon/bassoon-c#2.wav
+sample=../Samples/Bassoon/bassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
 tune=-17
 
 <region>
-sample=../Samples/bassoon/bassoon-e2.wav
+sample=../Samples/Bassoon/bassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
 tune=-12
 
 <region>
-sample=../Samples/bassoon/bassoon-g2.wav
+sample=../Samples/Bassoon/bassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 
 <region>
-sample=../Samples/bassoon/bassoon-a#2.wav
+sample=../Samples/Bassoon/bassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/bassoon/bassoon-c#3.wav
+sample=../Samples/Bassoon/bassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 tune=-12
 
 <region>
-sample=../Samples/bassoon/bassoon-e3.wav
+sample=../Samples/Bassoon/bassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 tune=-11
 
 <region>
-sample=../Samples/bassoon/bassoon-g3.wav
+sample=../Samples/Bassoon/bassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 tune=-5
 
 <region>
-sample=../Samples/bassoon/bassoon-a#3.wav
+sample=../Samples/Bassoon/bassoon-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 tune=-4
 
 <region>
-sample=../Samples/bassoon/bassoon-c#4.wav
+sample=../Samples/Bassoon/bassoon-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=5
 
 <region>
-sample=../Samples/bassoon/bassoon-e4.wav
+sample=../Samples/Bassoon/bassoon-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/bassoon/bassoon-g4.wav
+sample=../Samples/Bassoon/bassoon-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-13
 
 <region>
-sample=../Samples/bassoon/bassoon-a#4.wav
+sample=../Samples/Bassoon/bassoon-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 tune=-9
 
 <region>
-sample=../Samples/bassoon/bassoon-c#5.wav
+sample=../Samples/Bassoon/bassoon-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/bassoon-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/bassoon-solo.sfz
@@ -1,94 +1,94 @@
 
 <region>
-sample=../Samples/bassoon/bassoon-a#1.wav
+sample=../Samples/Bassoon/bassoon-a#1.wav
 lokey=a#1
 hikey=b1
 pitch_keycenter=a#1
 tune=-13
 
 <region>
-sample=../Samples/bassoon/bassoon-c#2.wav
+sample=../Samples/Bassoon/bassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
 tune=-17
 
 <region>
-sample=../Samples/bassoon/bassoon-e2.wav
+sample=../Samples/Bassoon/bassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
 tune=-12
 
 <region>
-sample=../Samples/bassoon/bassoon-g2.wav
+sample=../Samples/Bassoon/bassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
 
 <region>
-sample=../Samples/bassoon/bassoon-a#2.wav
+sample=../Samples/Bassoon/bassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 
 <region>
-sample=../Samples/bassoon/bassoon-c#3.wav
+sample=../Samples/Bassoon/bassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 tune=-12
 
 <region>
-sample=../Samples/bassoon/bassoon-e3.wav
+sample=../Samples/Bassoon/bassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
 tune=-11
 
 <region>
-sample=../Samples/bassoon/bassoon-g3.wav
+sample=../Samples/Bassoon/bassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
 tune=-5
 
 <region>
-sample=../Samples/bassoon/bassoon-a#3.wav
+sample=../Samples/Bassoon/bassoon-a#3.wav
 lokey=a3
 hikey=b3
 pitch_keycenter=a#3
 tune=-4
 
 <region>
-sample=../Samples/bassoon/bassoon-c#4.wav
+sample=../Samples/Bassoon/bassoon-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=5
 
 <region>
-sample=../Samples/bassoon/bassoon-e4.wav
+sample=../Samples/Bassoon/bassoon-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 
 <region>
-sample=../Samples/bassoon/bassoon-g4.wav
+sample=../Samples/Bassoon/bassoon-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-13
 
 <region>
-sample=../Samples/bassoon/bassoon-a#4.wav
+sample=../Samples/Bassoon/bassoon-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
 tune=-9
 
 <region>
-sample=../Samples/bassoon/bassoon-c#5.wav
+sample=../Samples/Bassoon/bassoon-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/clarinet-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/clarinet-solo.sfz
@@ -1,84 +1,84 @@
 
 <region>
-sample=../Samples/clarinet/clarinet-d3.wav
+sample=../Samples/Clarinet/clarinet-d3.wav
 lokey=d3
 hikey=d#3
 pitch_keycenter=d3
 tune=3
 
 <region>
-sample=../Samples/clarinet/clarinet-f3.wav
+sample=../Samples/Clarinet/clarinet-f3.wav
 lokey=e3
 hikey=f#3
 pitch_keycenter=f3
 
 <region>
-sample=../Samples/clarinet/clarinet-g#3.wav
+sample=../Samples/Clarinet/clarinet-g#3.wav
 lokey=g3
 hikey=a3
 pitch_keycenter=g#3
 
 <region>
-sample=../Samples/clarinet/clarinet-b3.wav
+sample=../Samples/Clarinet/clarinet-b3.wav
 lokey=a#3
 hikey=c4
 pitch_keycenter=b3
 tune=5
 
 <region>
-sample=../Samples/clarinet/clarinet-d4.wav
+sample=../Samples/Clarinet/clarinet-d4.wav
 lokey=c#4
 hikey=d#4
 pitch_keycenter=d4
 tune=6
 
 <region>
-sample=../Samples/clarinet/clarinet-f4.wav
+sample=../Samples/Clarinet/clarinet-f4.wav
 lokey=e4
 hikey=f#4
 pitch_keycenter=f4
 volume=-1
 
 <region>
-sample=../Samples/clarinet/clarinet-g#4.wav
+sample=../Samples/Clarinet/clarinet-g#4.wav
 lokey=g4
 hikey=a4
 pitch_keycenter=g#4
 tune=8
 
 <region>
-sample=../Samples/clarinet/clarinet-b4.wav
+sample=../Samples/Clarinet/clarinet-b4.wav
 lokey=a#4
 hikey=c5
 pitch_keycenter=b4
 
 <region>
-sample=../Samples/clarinet/clarinet-d5.wav
+sample=../Samples/Clarinet/clarinet-d5.wav
 lokey=c#5
 hikey=d#5
 pitch_keycenter=d5
 
 <region>
-sample=../Samples/clarinet/clarinet-f5.wav
+sample=../Samples/Clarinet/clarinet-f5.wav
 lokey=e5
 hikey=f#5
 pitch_keycenter=f5
 
 <region>
-sample=../Samples/clarinet/clarinet-g#5.wav
+sample=../Samples/Clarinet/clarinet-g#5.wav
 lokey=g5
 hikey=a5
 pitch_keycenter=g#5
 
 <region>
-sample=../Samples/clarinet/clarinet-b5.wav
+sample=../Samples/Clarinet/clarinet-b5.wav
 lokey=a#5
 hikey=c6
 pitch_keycenter=b5
 volume=1
 
 <region>
-sample=../Samples/clarinet/clarinet-d6.wav
+sample=../Samples/Clarinet/clarinet-d6.wav
 lokey=c#6
 hikey=d6
 pitch_keycenter=d6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/contrabassoon-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/contrabassoon-solo.sfz
@@ -1,32 +1,32 @@
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#0.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#0.wav
 lokey=a#0
 hikey=b0
 pitch_keycenter=a#0
 tune=-20
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#1.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#1.wav
 lokey=c1
 hikey=d1
 pitch_keycenter=c#1
 tune=-16
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e1.wav
+sample=../Samples/Contrabassoon/contrabassoon-e1.wav
 lokey=d#1
 hikey=f1
 pitch_keycenter=e1
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g1.wav
+sample=../Samples/Contrabassoon/contrabassoon-g1.wav
 lokey=f#1
 hikey=g#1
 pitch_keycenter=g1
 tune=-11
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#1.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#1.wav
 lokey=a1
 hikey=b1
 pitch_keycenter=a#1
@@ -34,19 +34,19 @@ tune=-18
 volume=2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#2.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#2.wav
 lokey=c2
 hikey=d2
 pitch_keycenter=c#2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e2.wav
+sample=../Samples/Contrabassoon/contrabassoon-e2.wav
 lokey=d#2
 hikey=f2
 pitch_keycenter=e2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g2.wav
+sample=../Samples/Contrabassoon/contrabassoon-g2.wav
 lokey=f#2
 hikey=g#2
 pitch_keycenter=g2
@@ -54,21 +54,21 @@ tune=-16
 volume=2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#2.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#2.wav
 lokey=a2
 hikey=b2
 pitch_keycenter=a#2
 volume=2
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-c#3.wav
+sample=../Samples/Contrabassoon/contrabassoon-c#3.wav
 lokey=c3
 hikey=d3
 pitch_keycenter=c#3
 tune=-13
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-e3.wav
+sample=../Samples/Contrabassoon/contrabassoon-e3.wav
 lokey=d#3
 hikey=f3
 pitch_keycenter=e3
@@ -76,7 +76,7 @@ tune=-16
 volume=-1
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-g3.wav
+sample=../Samples/Contrabassoon/contrabassoon-g3.wav
 lokey=f#3
 hikey=g#3
 pitch_keycenter=g3
@@ -84,7 +84,7 @@ tune=-7
 volume=-1
 
 <region>
-sample=../Samples/contrabassoon/contrabassoon-a#3.wav
+sample=../Samples/Contrabassoon/contrabassoon-a#3.wav
 lokey=a3
 hikey=a#3
 pitch_keycenter=a#3

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/flute-solo-1-staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/flute-solo-1-staccato.sfz
@@ -1,5 +1,5 @@
 <group>
-sample=../Samples/flute/flute-c3.wav
+sample=../Samples/Flute/flute-c3.wav
 lokey=c4
 hikey=c#4
 pitch_keycenter=c4
@@ -42,7 +42,7 @@ cutoff=2000
 
 
 <group>
-sample=../Samples/flute/flute-d#3.wav
+sample=../Samples/Flute/flute-d#3.wav
 lokey=d4
 hikey=e4
 pitch_keycenter=d#4
@@ -84,7 +84,7 @@ cutoff=2000
 
 
 <group>
-sample=../Samples/flute/flute-f#3.wav
+sample=../Samples/Flute/flute-f#3.wav
 lokey=f4
 hikey=g4
 pitch_keycenter=f#4
@@ -126,7 +126,7 @@ cutoff=2000
 
 
 <group>
-sample=../Samples/flute/flute-a3.wav
+sample=../Samples/Flute/flute-a3.wav
 lokey=g#4
 hikey=a#4
 pitch_keycenter=a4
@@ -166,7 +166,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-c4.wav
+sample=../Samples/Flute/flute-c4.wav
 lokey=b4
 hikey=c#5
 pitch_keycenter=c5
@@ -207,7 +207,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-d#4.wav
+sample=../Samples/Flute/flute-d#4.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
@@ -248,7 +248,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-f#4.wav
+sample=../Samples/Flute/flute-f#4.wav
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
@@ -289,7 +289,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-a4.wav
+sample=../Samples/Flute/flute-a4.wav
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
@@ -331,7 +331,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-c5.wav
+sample=../Samples/Flute/flute-c5.wav
 lokey=b5
 hikey=c#6
 pitch_keycenter=c6
@@ -373,7 +373,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-d#5.wav
+sample=../Samples/Flute/flute-d#5.wav
 lokey=d6
 hikey=e6
 pitch_keycenter=d#6
@@ -415,7 +415,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-f#5.wav
+sample=../Samples/Flute/flute-f#5.wav
 lokey=f6
 hikey=g6
 pitch_keycenter=f#6
@@ -457,7 +457,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-a5.wav
+sample=../Samples/Flute/flute-a5.wav
 lokey=g#6
 hikey=a#6
 pitch_keycenter=a6
@@ -498,7 +498,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/flute/flute-c6.wav
+sample=../Samples/Flute/flute-c6.wav
 lokey=b6
 hikey=c7
 pitch_keycenter=c7

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/flute-solo-1-sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/flute-solo-1-sustain.sfz
@@ -1,65 +1,65 @@
 <region>
-sample=../Samples/flute/flute-c3.wav
+sample=../Samples/Flute/flute-c3.wav
 lokey=c4
 hikey=c#4
 pitch_keycenter=c4
 volume=-1
 
 <region>
-sample=../Samples/flute/flute-d#3.wav
+sample=../Samples/Flute/flute-d#3.wav
 lokey=d4
 hikey=e4
 pitch_keycenter=d#4
 
 <region>
-sample=../Samples/flute/flute-f#3.wav
+sample=../Samples/Flute/flute-f#3.wav
 lokey=f4
 hikey=g4
 pitch_keycenter=f#4
 
 <region>
-sample=../Samples/flute/flute-a3.wav
+sample=../Samples/Flute/flute-a3.wav
 lokey=g#4
 hikey=a#4
 pitch_keycenter=a4
 
 <region>
-sample=../Samples/flute/flute-c4.wav
+sample=../Samples/Flute/flute-c4.wav
 lokey=b4
 hikey=c#5
 pitch_keycenter=c5
 tune=-16
 
 <region>
-sample=../Samples/flute/flute-d#4.wav
+sample=../Samples/Flute/flute-d#4.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
 tune=-7
 
 <region>
-sample=../Samples/flute/flute-f#4.wav
+sample=../Samples/Flute/flute-f#4.wav
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
 tune=-4
 
 <region>
-sample=../Samples/flute/flute-a4.wav
+sample=../Samples/Flute/flute-a4.wav
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
 tune=-17
 
 <region>
-sample=../Samples/flute/flute-c5.wav
+sample=../Samples/Flute/flute-c5.wav
 lokey=b5
 hikey=c#6
 pitch_keycenter=c6
 tune=-4
 
 <region>
-sample=../Samples/flute/flute-d#5.wav
+sample=../Samples/Flute/flute-d#5.wav
 lokey=d6
 hikey=e6
 pitch_keycenter=d#6
@@ -67,7 +67,7 @@ volume=-2
 tune=-8
 
 <region>
-sample=../Samples/flute/flute-f#5.wav
+sample=../Samples/Flute/flute-f#5.wav
 lokey=f6
 hikey=g6
 pitch_keycenter=f#6
@@ -75,14 +75,14 @@ volume=-3
 tune=-16
 
 <region>
-sample=../Samples/flute/flute-a5.wav
+sample=../Samples/Flute/flute-a5.wav
 lokey=g#6
 hikey=a#6
 pitch_keycenter=a6
 tune=-17
 
 <region>
-sample=../Samples/flute/flute-c6.wav
+sample=../Samples/Flute/flute-c6.wav
 lokey=b6
 hikey=c7
 pitch_keycenter=c7

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/oboe-solo.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/oboe-solo.sfz
@@ -1,33 +1,33 @@
 <region>
-sample=../Samples/oboe/oboe-a#3.wav
+sample=../Samples/Oboe/oboe-a#3.wav
 lokey=a#3
 hikey=b3
 pitch_keycenter=a#3
 tune=-8
 
 <region>
-sample=../Samples/oboe/oboe-c#4.wav
+sample=../Samples/Oboe/oboe-c#4.wav
 lokey=c4
 hikey=d4
 pitch_keycenter=c#4
 tune=-9
 
 <region>
-sample=../Samples/oboe/oboe-e4.wav
+sample=../Samples/Oboe/oboe-e4.wav
 lokey=d#4
 hikey=f4
 pitch_keycenter=e4
 tune=-14
 
 <region>
-sample=../Samples/oboe/oboe-g4.wav
+sample=../Samples/Oboe/oboe-g4.wav
 lokey=f#4
 hikey=g#4
 pitch_keycenter=g4
 tune=-10
 
 <region>
-sample=../Samples/oboe/oboe-a#4.wav
+sample=../Samples/Oboe/oboe-a#4.wav
 lokey=a4
 hikey=b4
 pitch_keycenter=a#4
@@ -35,14 +35,14 @@ tune=-5
 volume=-2
 
 <region>
-sample=../Samples/oboe/oboe-c#5.wav
+sample=../Samples/Oboe/oboe-c#5.wav
 lokey=c5
 hikey=d5
 pitch_keycenter=c#5
 volume=-2
 
 <region>
-sample=../Samples/oboe/oboe-e5.wav
+sample=../Samples/Oboe/oboe-e5.wav
 lokey=d#5
 hikey=f5
 pitch_keycenter=e5
@@ -50,21 +50,21 @@ tune=-15
 volume=4
 
 <region>
-sample=../Samples/oboe/oboe-g5.wav
+sample=../Samples/Oboe/oboe-g5.wav
 lokey=f#5
 hikey=g#5
 pitch_keycenter=g5
 tune=-20
 
 <region>
-sample=../Samples/oboe/oboe-a#5.wav
+sample=../Samples/Oboe/oboe-a#5.wav
 lokey=a5
 hikey=b5
 pitch_keycenter=a#5
 tune=-22
 
 <region>
-sample=../Samples/oboe/oboe-c6.wav
+sample=../Samples/Oboe/oboe-c6.wav
 lokey=c6
 hikey=d#6
 pitch_keycenter=c6

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/piccolo-solo-staccato.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/piccolo-solo-staccato.sfz
@@ -1,5 +1,5 @@
 <group>
-sample=../Samples/piccolo/piccolo-c4.wav
+sample=../Samples/Piccolo/piccolo-c4.wav
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
@@ -39,7 +39,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-d#4.wav
+sample=../Samples/Piccolo/piccolo-d#4.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
@@ -79,7 +79,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-f#4.wav
+sample=../Samples/Piccolo/piccolo-f#4.wav
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
@@ -119,7 +119,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-a4.wav
+sample=../Samples/Piccolo/piccolo-a4.wav
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
@@ -159,7 +159,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-c5.wav
+sample=../Samples/Piccolo/piccolo-c5.wav
 lokey=b5
 hikey=c#6
 pitch_keycenter=c6
@@ -199,7 +199,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-d#5.wav
+sample=../Samples/Piccolo/piccolo-d#5.wav
 lokey=d6
 hikey=e6
 pitch_keycenter=d#6
@@ -239,7 +239,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-f#5.wav
+sample=../Samples/Piccolo/piccolo-f#5.wav
 lokey=f6
 hikey=g6
 pitch_keycenter=f#6
@@ -279,7 +279,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-a5.wav
+sample=../Samples/Piccolo/piccolo-a5.wav
 lokey=g#6
 hikey=a#6
 pitch_keycenter=a6
@@ -320,7 +320,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-c6.wav
+sample=../Samples/Piccolo/piccolo-c6.wav
 lokey=b6
 hikey=c#7
 pitch_keycenter=c7
@@ -360,7 +360,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-d#6.wav
+sample=../Samples/Piccolo/piccolo-d#6.wav
 lokey=d7
 hikey=e7
 pitch_keycenter=d#7
@@ -400,7 +400,7 @@ ampeg_release=2
 
 
 <group>
-sample=../Samples/piccolo/piccolo-f#6.wav
+sample=../Samples/Piccolo/piccolo-f#6.wav
 lokey=f7
 hikey=g7
 pitch_keycenter=f#7

--- a/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/piccolo-solo-sustain.sfz
+++ b/Sonatina Symphonic Orchestra/Woodwinds - Performance/includes/piccolo-solo-sustain.sfz
@@ -1,66 +1,66 @@
 <region>
-sample=../Samples/piccolo/piccolo-c4.wav
+sample=../Samples/Piccolo/piccolo-c4.wav
 lokey=c5
 hikey=c#5
 pitch_keycenter=c5
 
 <region>
-sample=../Samples/piccolo/piccolo-d#4.wav
+sample=../Samples/Piccolo/piccolo-d#4.wav
 lokey=d5
 hikey=e5
 pitch_keycenter=d#5
 
 <region>
-sample=../Samples/piccolo/piccolo-f#4.wav
+sample=../Samples/Piccolo/piccolo-f#4.wav
 lokey=f5
 hikey=g5
 pitch_keycenter=f#5
 
 <region>
-sample=../Samples/piccolo/piccolo-a4.wav
+sample=../Samples/Piccolo/piccolo-a4.wav
 lokey=g#5
 hikey=a#5
 pitch_keycenter=a5
 
 <region>
-sample=../Samples/piccolo/piccolo-c5.wav
+sample=../Samples/Piccolo/piccolo-c5.wav
 lokey=b5
 hikey=c#6
 pitch_keycenter=c6
 
 <region>
-sample=../Samples/piccolo/piccolo-d#5.wav
+sample=../Samples/Piccolo/piccolo-d#5.wav
 lokey=d6
 hikey=e6
 pitch_keycenter=d#6
 
 <region>
-sample=../Samples/piccolo/piccolo-f#5.wav
+sample=../Samples/Piccolo/piccolo-f#5.wav
 lokey=f6
 hikey=g6
 pitch_keycenter=f#6
 
 <region>
-sample=../Samples/piccolo/piccolo-a5.wav
+sample=../Samples/Piccolo/piccolo-a5.wav
 lokey=g#6
 hikey=a#6
 pitch_keycenter=a6
 volume=2
 
 <region>
-sample=../Samples/piccolo/piccolo-c6.wav
+sample=../Samples/Piccolo/piccolo-c6.wav
 lokey=b6
 hikey=c#7
 pitch_keycenter=c7
 
 <region>
-sample=../Samples/piccolo/piccolo-d#6.wav
+sample=../Samples/Piccolo/piccolo-d#6.wav
 lokey=d7
 hikey=e7
 pitch_keycenter=d#7
 
 <region>
-sample=../Samples/piccolo/piccolo-f#6.wav
+sample=../Samples/Piccolo/piccolo-f#6.wav
 lokey=f7
 hikey=g7
 pitch_keycenter=f#7


### PR DESCRIPTION
Hi,

The references to filepaths for some instruments have capitalisation errors. This is not a problem on Windows because filepaths are not case-sensitive there, but on some OS's it is a problem and the affected instruments can't load. 